### PR TITLE
fixed default params

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,10 @@ fixtures:
   repositories:
     apache:           'https://github.com/puppetlabs/puppetlabs-apache'
     augeas_core:
-      repo: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
+      repo:           'https://github.com/puppetlabs/puppetlabs-augeas_core'
       puppet_version: '>= 6.0.0'    
     concat:           'https://github.com/puppetlabs/puppetlabs-concat'
+    extlib:           'https://github.com/voxpupuli/puppet-extlib'
     postgresql:       'https://github.com/puppetlabs/puppetlabs-postgresql'
     redis:            'https://github.com/voxpupuli/puppet-redis'
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,27 +1,27 @@
 # Configure an Apache vhost
 # @api private
 class pulpcore::apache {
-  $pulp_api_path = '/pulp/api'
-  $pulp_api_url = "http://${pulpcore::pulp_api_host}:${pulpcore::pulp_api_port}/pulp/api"
-  $pulp_content_path = '/pulp/content'
-  $pulp_content_url = "http://${pulpcore::pulp_content_host}:${pulpcore::pulp_content_port}/pulp/content"
+  $api_path = '/pulp/api'
+  $api_url = "http://${pulpcore::api_host}:${pulpcore::api_port}/pulp/api"
+  $content_path = '/pulp/content'
+  $content_url = "http://${pulpcore::content_host}:${pulpcore::content_port}/pulp/content"
 
   include apache
   apache::vhost { 'pulp':
     servername => $pulpcore::servername,
     port       => 80,
     priority   => '10',
-    docroot    => $pulpcore::pulp_webserver_static_dir,
+    docroot    => $pulpcore::webserver_static_dir,
     proxy_pass => [
       {
-        'path'         => $pulp_api_path,
-        'url'          => $pulp_api_url,
-        'reverse_urls' => [$pulp_api_path, $pulp_api_url],
+        'path'         => $api_path,
+        'url'          => $api_url,
+        'reverse_urls' => [$api_path, $api_url],
       },
       {
-        'path'         => $pulp_content_path,
-        'url'          => $pulp_content_url,
-        'reverse_urls' => [$pulp_content_path, $pulp_content_url],
+        'path'         => $content_path,
+        'url'          => $content_url,
+        'reverse_urls' => [$content_path, $content_url],
       },
     ],
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,22 +1,22 @@
 # Configures pulp3
 # @api private
 class pulpcore::config {
-  file { $pulpcore::pulp_config_dir:
+  file { $pulpcore::config_dir:
     ensure => directory,
   }
 
   file { $pulpcore::settings_file:
     ensure  => file,
     owner   => 'root',
-    group   => $pulpcore::pulp_group,
+    group   => $pulpcore::group,
     mode    => '0640',
     content => template('pulpcore/settings.py.erb'),
   }
 
-  file { [$pulpcore::pulp_user_home, $pulpcore::pulp_webserver_static_dir, $pulpcore::pulp_cache_dir]:
+  file { [$pulpcore::user_home, $pulpcore::webserver_static_dir, $pulpcore::cache_dir]:
     ensure => directory,
-    owner  => $pulpcore::pulp_user,
-    group  => $pulpcore::pulp_group,
+    owner  => $pulpcore::user,
+    group  => $pulpcore::group,
     mode   => '0755',
   }
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -14,9 +14,9 @@ class pulpcore::database {
   }
 
   include postgresql::server
-  postgresql::server::db { $pulpcore::database_name:
-    user     => $pulpcore::pulp_user,
-    password => postgresql_password($pulpcore::pulp_user, 'secret'),
+  postgresql::server::db { $pulpcore::postgresql_db_name:
+    user     => $pulpcore::user,
+    password => postgresql_password($pulpcore::user, $pulpcore::postgresql_db_password),
   }
 
   exec { 'django-admin migrate --noinput':
@@ -26,7 +26,7 @@ class pulpcore::database {
       "PULP_SETTINGS=${pulpcore::settings_file}",
     ],
     refreshonly => true,
-    require     => Postgresql::Server::Db[$pulpcore::database_name],
+    require     => Postgresql::Server::Db[$pulpcore::postgresql_db_name],
   }
 
   include redis

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,24 +1,59 @@
-# @summary A short summary of the purpose of this class
+# Manage your next generation Pulp server
 #
-# A description of what this class does
+# @param cache_dir
+#   Pulp cache directory
+#
+# @param config_dir
+#   Pulp configuration directory
+#
+# @param user
+#   Pulp user
+#
+# @param group
+#   Pulp user group
+#
+# @param user_home
+#   Pulp user home directory
+#
+# @param api_host
+#   API service host
+#
+# @param api_port
+#   API service port
+#
+# @param content_host
+#   Content service host
+#
+# @param content_port
+#   Content service port
+#
+# @param webserver_static_dir
+#   Directory for Pulp webserver static content
+#
+# @param postgresql_db_name
+#   Name of Pulp database
+#
+# @param postgresql_db_password
+#   Password of Pulp database
 #
 # @example
 #   include pulpcore
 class pulpcore (
-  Stdlib::Absolutepath $pulp_cache_dir = '/var/lib/pulpcore/tmp',
-  Stdlib::Absolutepath $pulp_config_dir = '/etc/pulpcore',
-  String $pulp_user = 'pulpcore',
-  String $pulp_group = 'pulpcore',
-  Stdlib::Absolutepath $pulp_user_home = '/var/lib/pulpcore',
-  Stdlib::Host $pulp_api_host = '127.0.0.1',
-  Stdlib::Port $pulp_api_port = 24817,
-  Stdlib::Host $pulp_content_host = '127.0.0.1',
-  Stdlib::Port $pulp_content_port = 24816,
-  Stdlib::Absolutepath $pulp_webserver_static_dir = '/var/lib/pulpcore/docroot',
-  String $database_name = 'pulpcore',
+  Stdlib::Absolutepath $cache_dir = '/var/lib/pulp/tmp',
+  Stdlib::Absolutepath $config_dir = '/etc/pulp',
+  String $user = 'pulp',
+  String $group = 'pulp',
+  Stdlib::Absolutepath $user_home = '/var/lib/pulp',
+  Stdlib::Host $api_host = '127.0.0.1',
+  Stdlib::Port $api_port = 24817,
+  Stdlib::Host $content_host = '127.0.0.1',
+  Stdlib::Port $content_port = 24816,
+  Stdlib::Absolutepath $webserver_static_dir = '/var/lib/pulp/docroot',
+  String $postgresql_db_name = 'pulpcore',
+  String $postgresql_db_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32)),
 ) {
 
-  $settings_file = "${pulp_config_dir}/settings.py"
+  $settings_file = "${config_dir}/settings.py"
   $servername = $facts['fqdn']
 
   include pulpcore::install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,14 +13,14 @@ class pulpcore::install {
     require  => Package[$system_packages],
   }
 
-  user { $pulpcore::pulp_user:
+  user { $pulpcore::user:
     ensure     => present,
-    gid        => $pulpcore::pulp_group,
-    home       => $pulpcore::pulp_user_home,
+    gid        => $pulpcore::group,
+    home       => $pulpcore::user_home,
     managehome => false,
   }
 
-  group { $pulpcore::pulp_group:
+  group { $pulpcore::group:
     ensure => present,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,10 @@
     {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 2.2.0 < 3.0.0"
+    },
+    {
+      "name": "puppet/extlib",
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -6,11 +6,11 @@ Wants=network-online.target
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
-User=<%= scope['pulpcore::pulp_user'] %>
+User=<%= scope['pulpcore::user'] %>
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
 ExecStart=/usr/local/bin/gunicorn pulpcore.app.wsgi:application \
-          --bind '<%= scope['pulpcore::pulp_api_host'] %>:<%= scope['pulpcore::pulp_api_port'] %>' \
+          --bind '<%= scope['pulpcore::api_host'] %>:<%= scope['pulpcore::api_port'] %>' \
           --access-logfile -
 ProtectSystem=full
 PrivateTmp=yes

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -6,11 +6,11 @@ Wants=network-online.target
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
-User=<%= scope['pulpcore::pulp_user'] %>
+User=<%= scope['pulpcore::user'] %>
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
 ExecStart=/usr/local/bin/gunicorn pulpcore.content:server \
-          --bind '<%= scope['pulpcore::pulp_content_host'] %>:<%= scope['pulpcore::pulp_content_port'] %>' \
+          --bind '<%= scope['pulpcore::content_host'] %>:<%= scope['pulpcore::content_port'] %>' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2 \
           --access-logfile -

--- a/templates/pulpcore-resource-manager.service.erb
+++ b/templates/pulpcore-resource-manager.service.erb
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
-User=<%= scope['pulpcore::pulp_user'] %>
+User=<%= scope['pulpcore::user'] %>
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager
 ExecStart=/usr/local/bin/rq worker \

--- a/templates/pulpcore-worker@.service.erb
+++ b/templates/pulpcore-worker@.service.erb
@@ -8,8 +8,8 @@ EnvironmentFile=-/etc/default/pulp-workers
 EnvironmentFile=-/etc/default/pulp-workers-%i
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
-User=<%= scope['pulpcore::pulp_user'] %>
-Group=<%= scope['pulpcore::pulp_group'] %>
+User=<%= scope['pulpcore::user'] %>
+Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
 ExecStart=/usr/local/bin/rq worker \

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -6,16 +6,16 @@ SECRET_KEY = "TODO"
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': '<%= scope['pulpcore::database_name'] %>',
-        'USER': '<%= scope['pulpcore::pulp_user'] %>',
-        'PASSWORD': 'secret',
+        'NAME': '<%= scope['pulpcore::postgresql_db_name'] %>',
+        'USER': '<%= scope['pulpcore::user'] %>',
+        'PASSWORD': '<%= scope['pulpcore::postgresql_db_password'] %>',
         'HOST': '127.0.0.1',
         'PORT': '5432',
     }
 }
-MEDIA_ROOT = "<%= scope['pulpcore::pulp_webserver_static_dir'] %>"
+MEDIA_ROOT = "<%= scope['pulpcore::webserver_static_dir'] %>"
 REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = 3
-WORKING_DIRECTORY = "<%= scope['pulpcore::pulp_cache_dir'] %>"
+WORKING_DIRECTORY = "<%= scope['pulpcore::cache_dir'] %>"
 CONTENT_ORIGIN = "http://<%= scope['pulpcore::servername'] %>"


### PR DESCRIPTION
In this PR, I have:

1. Changed default user, group, and paths to use 'pulp' instead of 'pulpcore' as required  by the migration tool

2. Shorted parameter names by removing redundant 'pulp_' prefixes

3. Commented parameters in manifests/init.pp

4. Added random generation of DB password