### PR TITLE
apache vhost can be externally managed

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -6,23 +6,25 @@ class pulpcore::apache {
   $content_path = '/pulp/content'
   $content_url = "http://${pulpcore::content_host}:${pulpcore::content_port}/pulp/content"
 
-  include apache
-  apache::vhost { 'pulp':
-    servername => $pulpcore::servername,
-    port       => 80,
-    priority   => '10',
-    docroot    => $pulpcore::webserver_static_dir,
-    proxy_pass => [
-      {
-        'path'         => $api_path,
-        'url'          => $api_url,
-        'reverse_urls' => [$api_path, $api_url],
-      },
-      {
-        'path'         => $content_path,
-        'url'          => $content_url,
-        'reverse_urls' => [$content_path, $content_url],
-      },
-    ],
+  if $pulpcore::manage_apache {
+    include apache
+    apache::vhost { 'pulp':
+      servername => $pulpcore::servername,
+      port       => 80,
+      priority   => '10',
+      docroot    => $pulpcore::webserver_static_dir,
+      proxy_pass => [
+        {
+          'path'         => $api_path,
+          'url'          => $api_url,
+          'reverse_urls' => [$api_path, $api_url],
+        },
+        {
+          'path'         => $content_path,
+          'url'          => $content_url,
+          'reverse_urls' => [$content_path, $content_url],
+        },
+      ],
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,9 @@
 # @param user_home
 #   Pulp user home directory
 #
+# @param manage_apache
+#   Deploy a separate apache vhost for pulp3
+#
 # @param api_host
 #   API service host
 #
@@ -44,6 +47,7 @@ class pulpcore (
   String $user = 'pulp',
   String $group = 'pulp',
   Stdlib::Absolutepath $user_home = '/var/lib/pulp',
+  Boolean $manage_apache = true,
   Stdlib::Host $api_host = '127.0.0.1',
   Stdlib::Port $api_port = 24817,
   Stdlib::Host $content_host = '127.0.0.1',


### PR DESCRIPTION
This resolves #11 and is needed for installer support since some scenarios require the apache vhost to be managed by another module