### PR TITLE
don't enable software collections

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 # @api private
 class pulpcore::install {
 
-  $system_packages = ['gcc', 'postgresql-devel', 'python3-pip', 'python3-devel', 'centos-release-scl-rh']
+  $system_packages = ['gcc', 'postgresql-devel', 'python3-pip', 'python3-devel']
 
   ensure_packages($system_packages)
 


### PR DESCRIPTION
`centos-release-scl-rh` is already installed on test setups and doesn't need to be enabled in the main module.