### PR TITLE
remove redundant reverse proxy declarations

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -17,12 +17,12 @@ class pulpcore::apache {
         {
           'path'         => $api_path,
           'url'          => $api_url,
-          'reverse_urls' => [$api_path, $api_url],
+          'reverse_urls' => [$api_url],
         },
         {
           'path'         => $content_path,
           'url'          => $content_url,
-          'reverse_urls' => [$content_path, $content_url],
+          'reverse_urls' => [$content_url],
         },
       ],
     }


### PR DESCRIPTION
We have redundantly defined reverse proxy urls which are not necessary for the service to function. This PR removes them.