### PR TITLE
Refresh collectstatic on the settings file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,7 @@ class pulpcore::config {
       "PULP_SETTINGS=${pulpcore::settings_file}",
     ],
     refreshonly => true,
+    subscribe   => File[$pulpcore::settings_file],
   }
 
 }


### PR DESCRIPTION
When the settings file changes, the `MEDIA_ROOT` might change which means the files should be collected again. This also ensures the settings file has been generated before collection happens.