### PR TITLE
fixes #28655 - support fetching files via /pulp/isos with pulp3

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -5,7 +5,39 @@ class pulpcore::apache {
   $api_url = "http://${pulpcore::api_host}:${pulpcore::api_port}${api_path}"
   $content_path = '/pulp/content'
   $content_url = "http://${pulpcore::content_host}:${pulpcore::content_port}${content_path}"
-
+  $iso_path = '/pulp/isos'
+  if $pulpcore::enable_pulpcore_file {
+    $proxy_pass = [
+      {
+        'path'         => $api_path,
+        'url'          => $api_url,
+        'reverse_urls' => [$api_url],
+      },
+      {
+        'path'         => $content_path,
+        'url'          => $content_url,
+        'reverse_urls' => [$content_url],
+      },
+      {
+        'path'         => $iso_path,
+        'url'          => $content_url,
+        'reverse_urls' => [$content_url],
+      },
+    ]
+  } else {
+    $proxy_pass = [
+      {
+        'path'         => $api_path,
+        'url'          => $api_url,
+        'reverse_urls' => [$api_url],
+      },
+      {
+        'path'         => $content_path,
+        'url'          => $content_url,
+        'reverse_urls' => [$content_url],
+      },
+    ]
+  }
   if $pulpcore::manage_apache {
     include apache
     apache::vhost { 'pulp':
@@ -13,18 +45,7 @@ class pulpcore::apache {
       port       => 80,
       priority   => '10',
       docroot    => $pulpcore::webserver_static_dir,
-      proxy_pass => [
-        {
-          'path'         => $api_path,
-          'url'          => $api_url,
-          'reverse_urls' => [$api_url],
-        },
-        {
-          'path'         => $content_path,
-          'url'          => $content_url,
-          'reverse_urls' => [$content_url],
-        },
-      ],
+      proxy_pass => $proxy_pass,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class pulpcore (
   String $group = 'pulp',
   Stdlib::Absolutepath $user_home = '/var/lib/pulp',
   Boolean $manage_apache = true,
+  Boolean $enable_pulpcore_file = false,
   Stdlib::Host $api_host = '127.0.0.1',
   Stdlib::Port $api_port = 24817,
   Stdlib::Host $content_host = '127.0.0.1',


### PR DESCRIPTION
should work with https://github.com/theforeman/puppet-foreman_proxy_content/pull/228 to ReverseProxy /pulp/isos to /pulp/content