### PR TITLE
Fixes #28654 - support client cert auth with pulp3

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -17,3 +17,4 @@ REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>
 WORKING_DIRECTORY = "<%= scope['pulpcore::cache_dir'] %>"
+REMOTE_USER_ENVIRON_NAME = 'HTTP_REMOTE_USER'


### PR DESCRIPTION
Fixes #28654

This patch updates settings.py to include REMOTE_USER_ENVIRONMENT_NAME = 'HTTP_REMOTE_USER'. This, along with a change to the vhost in puppet-foreman_proxy_content, will be necessary to support client cert auth with pulp3.