### PR TITLE
Fixes #29190 - Support EL8

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,3 +2,4 @@
 .travis.yml:
   beaker_sets:
     - centos7-64
+    - centos8-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,27 @@ matrix:
         - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
         - sudo service docker restart
 
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet5
+        - BEAKER_setfile=centos8-64{hostname=centos8-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet6
+        - BEAKER_setfile=centos8-64{hostname=centos8-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
 bundler_args: --without system_tests development
 dist: xenial

--- a/metadata.json
+++ b/metadata.json
@@ -43,13 +43,15 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     }
   ],

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -23,22 +23,22 @@ case $major {
 # $baseurl = "https://fedorapeople.org/groups/katello/releases/yum/nightly/pulpcore/el${major}/x86_64/"
 $baseurl = "http://koji.katello.org/releases/yum/katello-nightly/pulpcore/el${major}/x86_64/"
 
-file { 'pulpcore-repo-extra-config':
-  path    => '/etc/yum/pulpcore.conf',
-  content => 'module_hotfixes=1',
-  before  => Yumrepo['pulpcore'],
-}
+$pulpcore_repo_conf = @("CONF")
+[pulpcore]
+baseurl=${baseurl}
+gpgcheck=0
+module_hotfixes=1
+CONF
 
-yumrepo { 'pulpcore':
-  baseurl  => $baseurl,
-  gpgcheck => 0,
-  include  => 'file:///etc/yum/pulpcore.conf',
+file { '/etc/yum.repos.d/pulpcore.repo':
+  ensure  => file,
+  content => $pulpcore_repo_conf,
 }
 
 # Needed as a workaround for idempotency
 if $facts['os']['selinux']['enabled'] {
   package { 'pulpcore-selinux':
     ensure  => installed,
-    require => Yumrepo['pulpcore'],
+    require => File['/etc/yum.repos.d/pulpcore.repo'],
   }
 }


### PR DESCRIPTION
After marking el8 as a supported OS in metadata.json, I can run spec tests using el8 facts:

```
[wclark@perseids puppet-pulpcore]$ SPEC_FACTS_OS=centos-8-x86_64 bundle exec rspec spec/classes/plugin_migration_spec.rb 
...

Finished in 4.83 seconds (files took 5.29 seconds to load)
3 examples, 0 failures

[wclark@perseids puppet-pulpcore]$ SPEC_FACTS_OS=centos-8-x86_64 bundle exec rspec spec/classes/plugin_file_spec.rb 
...

Finished in 4.03 seconds (files took 5.54 seconds to load)
3 examples, 0 failures

[wclark@perseids puppet-pulpcore]$ SPEC_FACTS_OS=centos-8-x86_64 bundle exec rspec spec/classes/plugin_container_spec.rb 
...

Finished in 3.8 seconds (files took 5.1 seconds to load)
3 examples, 0 failures

[wclark@perseids puppet-pulpcore]$ SPEC_FACTS_OS=centos-8-x86_64 bundle exec rspec spec/classes/pulpcore_spec.rb 
.......

Finished in 19.54 seconds (files took 5.41 seconds to load)
7 examples, 0 failures

[wclark@perseids puppet-pulpcore]$ 
```