### PR TITLE
restorecon after creating cache dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,6 +25,10 @@ class pulpcore::config {
     owner  => $pulpcore::user,
     group  => $pulpcore::group,
     mode   => '0775',
+  } ~> exec { "restorecon -RvF ${pulpcore::cache_dir}":
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+    command     => "restorecon -RvF ${pulpcore::cache_dir}",
+    refreshonly => true,
   }
 
   pulpcore::admin { 'collectstatic --noinput':

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -16,6 +16,8 @@ describe 'pulpcore' do
           is_expected.to contain_postgresql__server__db('pulpcore')
           is_expected.to contain_apache__vhost('pulp')
           is_expected.to contain_selinux__boolean('httpd_can_network_connect')
+          is_expected.to contain_file('/var/lib/pulp/tmp')
+          is_expected.to contain_exec("restorecon -RvF /var/lib/pulp/tmp")
         end
       end
 


### PR DESCRIPTION
Previously, the catalogue is compiled before package `pulpcore-selinux` is installed, so the cache dir gets created with the wrong context initially. This breaks idempotence, as when the module is run a second time, it does so with the policy which is queried after `pulpcore-selinux` RPM is installed.

This change fixrd that issue by ensuring a `restorecon` is run after the directory gets created, so that it correctly gets the `pulpcore_var_lib_t` label defined in the policy by the `pulpcore-selinux` RPM even if that package wasn't installed at the time the catalogue is compiled.