### PR TITLE
Fixes #29371 - Update settings.py for pulpcore3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # puppet-pulpcore
 Puppet module for setting up Pulp 3 as part of Katello installation
+
+# Pulpcore 3.2
+
+We are adding a few new settings to make the installer compatible with pulpcore 3.2. These settings are not available in releases prior to 3.2 and should not be used in earlier versions.                                            
+
+**ALLOWED_IMPORT_PATHS** : This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests. For more information on this, see [https://docs.pulpproject.org/settings.html#allowed-import-paths](https://docs.pulpproject.org/settings.html#allowed-import-paths).
+
+**AUTHENTICATION_BACKENDS , REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES** : 
+The defaults that katello uses are defined in [templates/settings.py.erb](https://github.com/theforeman/puppet-pulpcore/blob/master/templates/settings.py.erb). For more information on these authentication settings, see [https://docs.pulpproject.org/installation/authentication.html](https://docs.pulpproject.org/installation/authentication.html) 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,9 @@
 # @param remote_user_environ_name
 #   Django remote user environment variable
 #
+# @param allowed_import_path
+#   Allowed paths that pulp can sync from using file:// protocol
+#
 # @example
 #   include pulpcore
 class pulpcore (
@@ -110,6 +113,7 @@ class pulpcore (
   String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(32)),
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['fqdn'],
+  Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],
   Optional[String] $remote_user_environ_name = undef,
 ) {
 

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -120,6 +120,30 @@ describe 'pulpcore' do
         end
       end
 
+      context 'with allowed import paths' do
+        let :params do
+          {
+            allowed_import_path: ['/test/path', '/test/path2'],
+          }
+        end
+
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/test/path", "/test/path2"\]})
+
+        end
+      end
+
+      context 'with empty allowed import paths' do
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
+
+        end
+      end
+
       context 'with custom static dirs' do
         let :params do
           {

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -27,3 +27,12 @@ WORKING_DIRECTORY = "<%= scope['pulpcore::cache_dir'] %>"
 <% if scope['pulpcore::remote_user_environ_name'] -%>
 REMOTE_USER_ENVIRON_NAME = '<%= scope['pulpcore::remote_user_environ_name'] %>'
 <% end -%>
+AUTHENTICATION_BACKENDS = ['pulpcore.app.authentication.PulpNoCreateRemoteUserBackend']
+
+REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
+    'rest_framework.authentication.SessionAuthentication',
+    'pulpcore.app.authentication.PulpRemoteUserAuthentication'
+)
+
+<%# This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
+ALLOWED_IMPORT_PATHS = <%= scope['pulpcore::allowed_import_path'] %>


### PR DESCRIPTION
We are working on getting pulpcore3.2 built and released. This is required to support the changes required to pulp/settings 

@wbclark : This is the the only place I identified a need for changes to support pulpcore 3.2 with this module. Is there anything else that you can think of that needs to be done?