### PR TITLE
install rh-redis5-redis in el7 acceptance spec

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,6 +33,7 @@ RSpec.configure do |c|
 
         if major == '7' && fact_on(host, 'os.name') == 'CentOS'
           host.install_package('centos-release-scl-rh')
+          host.install_package('rh-redis5-redis')
         end
 
         baseurl = if ENV['PULPCORE_REPO_RELEASE']


### PR DESCRIPTION
This should resolve (rather, hide) the other idempotence issue in the el7 acceptance tests, by ensuring the redis packages are installed already at the time our catalogue is compiled.