### PR TITLE
Pin Facter to < 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 5.5'
 
+# https://github.com/voxpupuli/puppet-selinux/issues/318
+gem 'facter', '< 4'
+
 gem 'rake'
 gem 'rspec', '~> 3.0'
 gem 'rspec-puppet', '~> 2.3'


### PR DESCRIPTION
The selinux_python_command fact in puppet-selinux is incompatible with Facter 4 when testing on non-Red Hat distributions.