### PR TITLE
Create admin user

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -16,6 +16,12 @@ class pulpcore::database {
     refreshonly => false,
   }
 
+  pulpcore::admin { 'reset-admin-password --random':
+    unless      => 'python3-django-admin dumpdata auth.User | grep "auth.user"',
+    refreshonly => false,
+    require     => Pulpcore::Admin['migrate --noinput'],
+  }
+
   include redis
 
 }

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -54,4 +54,9 @@ describe 'basic installation' do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
+ describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py python3-django-admin dumpdata auth.User") do
+   its(:stdout) { is_expected.to match(/auth\.user/) }
+   its(:exit_status) { is_expected.to eq 0 }
+ end
+
 end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -16,6 +16,7 @@ describe 'pulpcore' do
           is_expected.to contain_postgresql__server__db('pulpcore')
           is_expected.to contain_apache__vhost('pulp')
           is_expected.to contain_selinux__boolean('httpd_can_network_connect')
+          is_expected.to contain_pulpcore__admin('reset-admin-password --random')
         end
       end
 


### PR DESCRIPTION
We need to create the default admin user since pulpcore.app.authentication.PulpNoCreateRemoteUserBackend authentication backend does not create it automatically for us.