### PR TITLE
Refs #29371 - use django syntax to set DRF authenticators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ We are adding a few new settings to make the installer compatible with pulpcore 
 
 **ALLOWED_IMPORT_PATHS** : This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests. For more information on this, see [https://docs.pulpproject.org/settings.html#allowed-import-paths](https://docs.pulpproject.org/settings.html#allowed-import-paths).
 
-**AUTHENTICATION_BACKENDS , REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES** : 
+**AUTHENTICATION_BACKENDS , REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']** : 
 The defaults that katello uses are defined in [templates/settings.py.erb](https://github.com/theforeman/puppet-pulpcore/blob/master/templates/settings.py.erb). For more information on these authentication settings, see [https://docs.pulpproject.org/installation/authentication.html](https://docs.pulpproject.org/installation/authentication.html) 

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -29,10 +29,12 @@ REMOTE_USER_ENVIRON_NAME = '<%= scope['pulpcore::remote_user_environ_name'] %>'
 <% end -%>
 AUTHENTICATION_BACKENDS = ['pulpcore.app.authentication.PulpNoCreateRemoteUserBackend']
 
-REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
-    'rest_framework.authentication.SessionAuthentication',
-    'pulpcore.app.authentication.PulpRemoteUserAuthentication'
-)
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'pulpcore.app.authentication.PulpRemoteUserAuthentication'
+    )
+}
 
 <%# This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
 ALLOWED_IMPORT_PATHS = <%= scope['pulpcore::allowed_import_path'] %>


### PR DESCRIPTION
After longish reading of https://docs.pulpproject.org/installation/authentication.html, I think that the `REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES` is supposed to be used as an environment variable, while `settings.py` is a Django settings file, so it needs proper Python dicts :)

After changing this, I could create file repos again.

@sjha4 can you have a look please?