### PR TITLE
Update pulpcore::admin to use the command parameter if it is passed

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -30,7 +30,7 @@ define pulpcore::admin(
   Stdlib::Absolutepath $static_root = $pulpcore::pulp_static_root,
 ) {
   Concat <| title == 'pulpcore settings' |>
-  -> exec { "python3-django-admin ${title}":
+  -> exec { "python3-django-admin ${command}":
     path        => $path,
     environment => [
       'DJANGO_SETTINGS_MODULE=pulpcore.app.settings',

--- a/spec/defines/admin_spec.rb
+++ b/spec/defines/admin_spec.rb
@@ -40,7 +40,7 @@ describe 'pulpcore::admin' do
 
           it do
             is_expected.to compile.with_all_deps
-            is_expected.to contain_exec('python3-django-admin help')
+            is_expected.to contain_exec('python3-django-admin migrate --noinput')
               .with_environment([
                 'DJANGO_SETTINGS_MODULE=pulpcore.app.settings',
                 'PULP_SETTINGS=/etc/pulpcore/settings.py',


### PR DESCRIPTION
In pulpcore::admin, there is a `$command` parameter that defaults to `$title`.  However, `$command` is never used, and `${title}` is used inside an exec where the $command ought to be.