### PR TITLE
Refs #30133 - Unconditionally install RHSM

### DIFF
--- a/manifests/plugin/certguard.pp
+++ b/manifests/plugin/certguard.pp
@@ -1,10 +1,8 @@
 # @summary Pulp Certguard plugin
 class pulpcore::plugin::certguard {
-  if $facts['os']['release']['major'] == '7' {
-    package { 'python3-subscription-manager-rhsm':
-      ensure => present,
-    }
+  package { 'python3-subscription-manager-rhsm':
+    ensure => present,
   }
-  pulpcore::plugin { 'certguard':
+  -> pulpcore::plugin { 'certguard':
   }
 }

--- a/spec/classes/plugin_certguard_spec.rb
+++ b/spec/classes/plugin_certguard_spec.rb
@@ -6,11 +6,8 @@ describe 'pulpcore::plugin::certguard' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile.with_all_deps }
-      case os
-      when /\-7-/
-         it { is_expected.to contain_package('python3-subscription-manager-rhsm').with(ensure: 'present') }
-      end
-      it { is_expected.to contain_pulpcore__plugin('certguard') } 
+      it { is_expected.to contain_package('python3-subscription-manager-rhsm').with(ensure: 'present') }
+      it { is_expected.to contain_pulpcore__plugin('certguard') }
 
       context 'with pulpcore' do
         let(:pre_condition) { 'include pulpcore' }
@@ -18,6 +15,7 @@ describe 'pulpcore::plugin::certguard' do
         it do
           is_expected.to compile.with_all_deps
           is_expected.to contain_pulpcore__plugin('certguard')
+            .that_requires('Package[python3-subscription-manager-rhsm]')
             .that_subscribes_to('Class[Pulpcore::Install]')
             .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
         end


### PR DESCRIPTION
python3-subscription-manager-rhsm is needed on both EL7 and EL8. On EL7 it's not part of the base OS since rhsm is using Python 2. On EL8 it's installed when subscription-manager is. However, it's good to be explicit about what you need to function. Likely to be present is not good enough.