### PR TITLE
Introduce a curl_command helper

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -61,8 +61,8 @@ describe 'basic installation' do
     it { is_expected.to be_listening }
   end
 
-  describe command("curl -s http://#{host_inventory['fqdn']}/pulp/api/v3/status/ -w '%{response_code}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("200") }
+  describe curl_command("http://#{host_inventory['fqdn']}/pulp/api/v3/status/") do
+    its(:response_code) { is_expected.to eq(200) }
     its(:exit_status) { is_expected.to eq 0 }
   end
 

--- a/spec/acceptance/plugins_spec.rb
+++ b/spec/acceptance/plugins_spec.rb
@@ -60,8 +60,8 @@ describe 'basic installation' do
     it { is_expected.to be_listening }
   end
 
-  describe command("curl -s http://#{host_inventory['fqdn']}/pulp/api/v3/status/ -w '%{response_code}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("200") }
+  describe curl_command("http://#{host_inventory['fqdn']}/pulp/api/v3/status/") do
+    its(:response_code) { is_expected.to eq(200) }
     its(:exit_status) { is_expected.to eq 0 }
   end
 

--- a/spec/support/acceptance/curl_command.rb
+++ b/spec/support/acceptance/curl_command.rb
@@ -1,0 +1,63 @@
+# https://github.com/mizzy/serverspec/pull/611 was rejected so adding it here.
+begin
+  require 'serverspec'
+
+  module Serverspec
+    module Type
+      class CurlCommand < Command
+        def response_code
+          m = /Response-Code: (?<code>\d+)/.match(stderr)
+          return 0 unless m
+          m[:code].to_i
+        end
+
+        def body
+          command_result.stdout
+        end
+
+        def body_as_json
+          MultiJson.load(body)
+        end
+
+        private
+
+        def curl_command
+          command = "curl --silent --write-out '%{stderr}Response-Code: %{response_code}\\n' '#{@name}'"
+
+          @options.each do |option, value|
+            case option
+            when :cacert, :cert, :key
+              command += " --#{option} '#{value}'"
+            when :headers
+              value.each do |header, header_value|
+                if header_value
+                  command += " --header '#{header}: #{header_value}'"
+                else
+                  command += " --header '#{header};'"
+                end
+              end
+            else
+              raise "Unknown option #{option} (value: #{value})"
+            end
+          end
+
+          command
+        end
+
+        def command_result
+          @command_result ||= @runner.run_command(curl_command)
+        end
+      end
+    end
+
+    module Helper
+      module Type
+        def curl_command(*args)
+          Serverspec::Type::CurlCommand.new(*args)
+        end
+      end
+    end
+  end
+rescue LoadError
+  # serverspec not present - usually in unit tests
+end


### PR DESCRIPTION
This aims to reduce the duplication in curl verifications and also allows checking both the body and the response code.

Since this is also usable outside of puppet-pulpcore, I aim to add this in a reusable place. This PR is here to verify it works in CI and share.