### PR TITLE
Fixes #30423 - Change the application layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,39 @@ The module provides no guarantee for multiple versions. Whenever a version is dr
 ### Pulpcore 3.6
 
 Due to the use of libexec wrappers, at least python3-pulpcore 3.6.3-2 must be installed
+
+Supports EL 7 & 8, following [pulpcore-packaging](https://github.com/theforeman/pulpcore-packaging) only RPM specs are present.
+
+## Installation layout
+
+Pulpcore doesn't mandate a specific layout so this module creates and manages this. There are some constraints, mostly due to SELinux support.
+
+As part of the installation, it creates a user (default `pulp`) and group (default `pulp`). This user gets a home directory (default `/var/lib/pulp`). There is also a config dir (default `/etc/pulp`) under which a `settings.py` file is created.
+
+The media root (default `/var/lib/pulp/media`) refers to the [MEDIA_ROOT setting](https://docs.djangoproject.com/en/2.2/ref/settings/#media-root). In Pulp this should not be served by Apache. Instead of [MEDIA_URL](https://docs.djangoproject.com/en/2.2/ref/settings/#media-url) Pulp has a dedicated `pulpcore-content` service which can also perform permission checks. Only the Pulp services need to read the files so directory permissions are set to `0750`. Note this default differs from [Pulp's default](https://docs.pulpproject.org/settings.html#media-root). A subdirectory of the home directory allows a stricter lockdown and avoids any risk of uploading media files into the wrong directory.
+
+There are also the [STATIC_ROOT](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-STATIC_ROOT) and [STATIC_URL](https://docs.djangoproject.com/en/2.2/ref/settings/#static-url) settings. These serve the static assets used by Pulp. This includes CSS and Javascript for the HTML pages. They're not needed for the application to function, but make browsing the API more convenient.
+
+These is also the `cache_dir` which is used to configure [WORKING_DIRECTORY](https://docs.pulpproject.org/settings.html#working-directory) and [FILE_UPLOAD_TEMP_DIR](https://docs.djangoproject.com/en/2.2/ref/settings/#file-upload-temp-dir). This defaults to `/var/lib/pulp/tmp`. It is strongly recommended that this is on the same filesystem as `MEDIA_ROOT`.
+
+There is also `chunked_upload_dir` to configure the undocumented `CHUNKED_UPLOAD_DIR`. This directory stores the temporary files used for files uploaded as chunks.
+
+Apache is configured to use an empty directory as docroot (`$apache_docroot`, default `/var/lib/pulp/docroot`). Doing so prevents Apache from bypassing the Pulp content app. When Apache is not managed, this directory is not managed.
+
+While Pulp can create most of these directories at runtime, they're explicitly managed to set the correct permissions and, if pulpcore-selinux is installed, enforce the correct labels.
+
+This results into the following structure, using `tree -pug`:
+```
+/
+├── [drwxr-xr-x root     root    ]  etc
+│   └── [drwxr-xr-x root     pulp    ]  pulp ($config_dir)
+│       └── [-rw-r----- root     pulp    ]  settings.py
+└── [drwxr-xr-x root     root    ]  var
+    └── [drwxr-xr-x root     root    ]  lib
+        └── [drwxrwxr-x pulp     pulp    ]  pulp ($user_home)
+            ├── [drwxr-xr-x pulp     pulp    ]  assets ($static_root)
+            ├── [drwxr-xr-x pulp     pulp    ]  docroot ($apache_docroot)
+            ├── [drwxr-x--- pulp     pulp    ]  media ($media_root)
+            ├── [drwxr-x--- pulp     pulp    ]  tmp ($cache_dir)
+            └── [drwxr-x--- pulp     pulp    ]  upload ($chunked_upload_dir)
+```

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -9,11 +9,15 @@ class pulpcore::apache {
   if $pulpcore::manage_apache {
     include apache
     apache::vhost { 'pulpcore':
-      servername => $pulpcore::servername,
-      port       => 80,
-      priority   => '10',
-      docroot    => $pulpcore::webserver_static_dir,
-      proxy_pass => [
+      servername     => $pulpcore::servername,
+      port           => 80,
+      priority       => '10',
+      docroot        => $pulpcore::apache_docroot,
+      docroot_owner  => $pulpcore::user,
+      docroot_group  => $pulpcore::group,
+      docroot_mode   => '0755',
+      manage_docroot => true,
+      proxy_pass     => [
         {
           'path'         => $api_path,
           'url'          => $api_url,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,9 @@
 class pulpcore::config {
   file { $pulpcore::config_dir:
     ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
   }
 
   concat { 'pulpcore settings':
@@ -20,11 +23,18 @@ class pulpcore::config {
     order   => '01',
   }
 
-  file { [$pulpcore::user_home, $pulpcore::webserver_static_dir, $pulpcore::cache_dir]:
+  file { $pulpcore::user_home:
     ensure => directory,
     owner  => $pulpcore::user,
     group  => $pulpcore::group,
     mode   => '0775',
+  }
+
+  file { [$pulpcore::cache_dir, $pulpcore::chunked_upload_dir, $pulpcore::media_root]:
+    ensure => directory,
+    owner  => $pulpcore::user,
+    group  => $pulpcore::group,
+    mode   => '0750',
   }
 
   selinux::port { 'pulpcore-api-port':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,5 @@
 # Manage your next generation Pulp server
 #
-# @param cache_dir
-#   Pulp cache directory
-#
-# @param config_dir
-#   Pulp configuration directory
-#
 # @param user
 #   Pulp user
 #
@@ -30,11 +24,34 @@
 # @param content_port
 #   Content service port
 #
-# @param webserver_static_dir
-#   Directory for Pulp webserver static content
+# @param config_dir
+#   Pulp configuration directory. The settings.py file is created under this
+#   directory.
 #
-# @param pulp_static_root
-#   Root directory for collected static content
+# @param cache_dir
+#   Pulp cache directory. This is used to configure WORKING_DIRECTORY and
+#   FILE_UPLOAD_TEMP_DIR.
+#
+# @param chunked_upload_dir
+#   Pulp chunked upload directory. This is used to configure CHUNKED_UPLOAD_DIR
+#   and is used by Pulp to temporarily store files that are uploaded in chunks.
+#
+# @param apache_docroot
+#   Root directory for the Apache vhost. Only created if the Apache vhost is
+#   managed by this module.
+#
+# @param media_root
+#   Directory for Pulp's uploaded media. This corresponds to the MEDIA_ROOT
+#   setting.
+#
+# @param static_root
+#   Root directory for collected static content. This corresponds to the
+#   STATIC_ROOT setting.
+#
+# @param static_url
+#   The "URL" that serves the collected static content. This corresponds to the
+#   STATIC_URL setting. In reality this can also be just the path and doesn't
+#   have to be a full URL.
 #
 # @param postgresql_db_name
 #   Name of Pulp PostgreSQL database
@@ -89,21 +106,26 @@
 #   available, likely results in performance degradation due to I/O blocking and is not recommended in most cases. Modifying this parameter should
 #   be done incrementally with benchmarking at each step to determine an optimal value for your deployment.
 #
-# @example
+# @example Default configuration
 #   include pulpcore
+#
+# @see https://docs.djangoproject.com/en/2.2/howto/static-files/
 class pulpcore (
-  Stdlib::Absolutepath $cache_dir = '/var/lib/pulp/tmp',
-  Stdlib::Absolutepath $config_dir = '/etc/pulp',
   String $user = 'pulp',
   String $group = 'pulp',
   Stdlib::Absolutepath $user_home = '/var/lib/pulp',
+  Stdlib::Absolutepath $config_dir = '/etc/pulp',
+  Stdlib::Absolutepath $cache_dir = '/var/lib/pulp/tmp',
+  Stdlib::Absolutepath $chunked_upload_dir = '/var/lib/pulp/upload',
+  Stdlib::Absolutepath $media_root = '/var/lib/pulp/media',
+  Stdlib::Absolutepath $static_root = '/var/lib/pulp/assets',
+  String[1] $static_url = '/assets/',
+  Stdlib::Absolutepath $apache_docroot = '/var/lib/pulp/docroot',
   Boolean $manage_apache = true,
   Stdlib::Host $api_host = '127.0.0.1',
   Stdlib::Port $api_port = 24817,
   Stdlib::Host $content_host = '127.0.0.1',
   Stdlib::Port $content_port = 24816,
-  Stdlib::Absolutepath $webserver_static_dir = '/var/lib/pulp/docroot',
-  Stdlib::Absolutepath $pulp_static_root = '/var/lib/pulp/assets',
   String $postgresql_db_name = 'pulpcore',
   String $postgresql_db_user = 'pulp',
   String $postgresql_db_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32)),

--- a/manifests/static.pp
+++ b/manifests/static.pp
@@ -1,7 +1,7 @@
 # @summary Manage the static files (assets)
 # @api private
 class pulpcore::static {
-  file { $pulpcore::pulp_static_root:
+  file { $pulpcore::static_root:
     ensure => directory,
     owner  => $pulpcore::user,
     group  => $pulpcore::group,
@@ -11,6 +11,6 @@ class pulpcore::static {
   pulpcore::admin { 'collectstatic --noinput':
     refreshonly => true,
     subscribe   => Concat['pulpcore settings'],
-    require     => File[$pulpcore::pulp_static_root],
+    require     => File[$pulpcore::static_root],
   }
 }

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -24,8 +24,11 @@ describe 'pulpcore' do
             .without_content(/sslmode/)
           is_expected.to contain_file('/etc/pulp')
           is_expected.to contain_file('/var/lib/pulp')
+          is_expected.to contain_file('/var/lib/pulp/assets')
+          is_expected.to contain_file('/var/lib/pulp/media')
           is_expected.to contain_file('/var/lib/pulp/docroot')
           is_expected.to contain_file('/var/lib/pulp/tmp')
+          is_expected.to contain_file('/var/lib/pulp/upload')
         end
 
         it 'sets up static files' do
@@ -128,6 +131,7 @@ describe 'pulpcore' do
 
         it do
           is_expected.to compile.with_all_deps
+          is_expected.not_to contain_file('/var/lib/pulp/docroot')
           is_expected.not_to contain_apache__vhost('pulpcore')
           is_expected.not_to contain_selinux__boolean('httpd_can_network_connect')
         end
@@ -255,19 +259,21 @@ describe 'pulpcore' do
       context 'with custom static dirs' do
         let :params do
           {
-            webserver_static_dir: '/my/custom/directory',
-            pulp_static_root: '/my/other/custom/directory',
+            apache_docroot: '/my/custom/directory',
+            media_root: '/my/media/root',
+            static_root: '/my/other/custom/directory',
           }
         end
 
         it do
           is_expected.to compile.with_all_deps
           is_expected.to contain_file('/my/custom/directory')
-          is_expected.to contain_systemd__unit_file('pulpcore-api.service')
+          is_expected.to contain_file('/my/media/root')
+          is_expected.to contain_file('/my/other/custom/directory')
           is_expected.to contain_apache__vhost('pulpcore')
             .with_docroot('/my/custom/directory')
           is_expected.to contain_concat__fragment('base')
-            .with_content(%r{MEDIA_ROOT = "/my/custom/directory"})
+            .with_content(%r{MEDIA_ROOT = "/my/media/root"})
             .with_content(%r{STATIC_ROOT = "/my/other/custom/directory"})
         end
       end

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,12 +19,17 @@ DATABASES = {
 <% end -%>
     },
 }
-MEDIA_ROOT = "<%= scope['pulpcore::webserver_static_dir'] %>"
-STATIC_ROOT = "<%= scope['pulpcore::pulp_static_root'] %>"
 REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>
+
+MEDIA_ROOT = "<%= scope['pulpcore::media_root'] %>"
+STATIC_ROOT = "<%= scope['pulpcore::static_root'] %>"
+STATIC_URL = "<%= scope['pulpcore::static_url'] %>"
+FILE_UPLOAD_TEMP_DIR = "<%= scope['pulpcore::cache_dir'] %>"
 WORKING_DIRECTORY = "<%= scope['pulpcore::cache_dir'] %>"
+CHUNKED_UPLOAD_DIR = "<%= scope['pulpcore::chunked_upload_dir'] %>"
+
 <% if scope['pulpcore::remote_user_environ_name'] -%>
 REMOTE_USER_ENVIRON_NAME = '<%= scope['pulpcore::remote_user_environ_name'] %>'
 <% end -%>


### PR DESCRIPTION
This explicitly sets the all directories and documents the layout. It diverges from the upstream defaults in that MEDIA_ROOT is set to a subdirectory and the directory permissions are stricter than upstream.  The assets are served in static since this works around some SELinux issue.

Upstream this layout is proposed as the default. https://pulp.plan.io/issues/7178 has been opened for that.

It's an alternative to https://github.com/theforeman/puppet-pulpcore/pull/113. It will need a migration in the installer to move any generated content.