### PR TITLE
Fixes #30465 - Use libexec wrappers for SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # puppet-pulpcore
-Puppet module for setting up Pulp 3 as part of Katello installation
 
-# Pulpcore 3.2
+Puppet module to set up Pulp 3. The primary goal of the maintainers is to set up Pulp 3 as part of Katello installation, but there's no reason it couldn't be used elsewhere.
 
-We are adding a few new settings to make the installer compatible with pulpcore 3.2. These settings are not available in releases prior to 3.2 and should not be used in earlier versions.
+## Support policy
 
-**ALLOWED_IMPORT_PATHS** : This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests. For more information on this, see [https://docs.pulpproject.org/settings.html#allowed-import-paths](https://docs.pulpproject.org/settings.html#allowed-import-paths).
+The module provides no guarantee for multiple versions. Whenever a version is dropped, the major version is increased. All supported versions are listed.
 
-**AUTHENTICATION_BACKENDS , REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES** :
-The defaults that katello uses are defined in [templates/settings.py.erb](https://github.com/theforeman/puppet-pulpcore/blob/master/templates/settings.py.erb). For more information on these authentication settings, see [https://docs.pulpproject.org/installation/authentication.html](https://docs.pulpproject.org/installation/authentication.html)
+### Pulpcore 3.6
+
+Due to the use of libexec wrappers, at least python3-pulpcore 3.6.3-2 must be installed

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -10,7 +10,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=~
 RuntimeDirectory=pulpcore-api
-ExecStart=/usr/bin/gunicorn pulpcore.app.wsgi:application \
+ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.app.wsgi:application \
           --bind '<%= scope['pulpcore::api_host'] %>:<%= scope['pulpcore::api_port'] %>' \
           --access-logfile -
 ProtectSystem=full

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -10,7 +10,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=~
 RuntimeDirectory=pulpcore-content
-ExecStart=/usr/bin/gunicorn pulpcore.content:server \
+ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
           --bind '<%= scope['pulpcore::content_host'] %>:<%= scope['pulpcore::content_port'] %>' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2 \

--- a/templates/pulpcore-resource-manager.service.erb
+++ b/templates/pulpcore-resource-manager.service.erb
@@ -11,7 +11,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=~
 RuntimeDirectory=pulpcore-resource-manager
-ExecStart=/usr/bin/rq worker \
+ExecStart=/usr/libexec/pulpcore/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager \
           -c 'pulpcore.rqconfig' \
           --disable-job-desc-logging

--- a/templates/pulpcore-worker@.service.erb
+++ b/templates/pulpcore-worker@.service.erb
@@ -13,7 +13,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=~
 RuntimeDirectory=pulpcore-worker-%i
-ExecStart=/usr/bin/rq worker \
+ExecStart=/usr/libexec/pulpcore/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
           -c 'pulpcore.rqconfig' \
           --disable-job-desc-logging


### PR DESCRIPTION
In python3-pulpcore 3.7.1-2 the `/usr/libexec/pulpcore` wrappers have been introduced to enter the proper SELinux domain.

It has also been cherry picked to 3.6.3-2 but in the SELinux policy is incomplete so it has no effect. The main benefit of that cherry pick is to keep the module compatible with both 3.6 and 3.7.

The README is updated with a support policy. Since 3.7 is not being tested in CI yet, I have not yet added it to the supported versions.