### PR TITLE
Refs #30780 - set proper content origin setting

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -1,5 +1,5 @@
 CONTENT_HOST = "<%= scope['pulpcore::servername'] %>"
-CONTENT_ORIGIN = "http://<%= scope['pulpcore::servername'] %>"
+CONTENT_ORIGIN = "https://<%= scope['pulpcore::servername'] %>"
 SECRET_KEY = "<%= scope['pulpcore::django_secret_key'] %>"
 DATABASES = {
     'default': {


### PR DESCRIPTION
CONTENT_ORIGIN needs to be poitned at https:// for the
/pulp/container/ redirect to work properly