### PR TITLE
Handle X-Forwarded-Proto headers

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -37,3 +37,6 @@ REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
 
 <%# This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
 ALLOWED_IMPORT_PATHS = <%= scope['pulpcore::allowed_import_path'] %>
+
+# Derive HTTP/HTTPS via the X-Forwarded-Proto header set by Apache
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
In a reverse proxy setup, the process is running on HTTP only, but Apache is running on both HTTP and HTTPS. To let Django know, Apache sends the X-Forwarded-Proto header[1]. The Django settings documentation suggests this solution[2].

Apache sets these headers by default[3], but I don't know what happens if a clients sets them as well. Does Apache use those or explicitly sets its own?

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
[2]: https://docs.djangoproject.com/en/2.2/ref/settings/#secure-proxy-ssl-header
[3]: https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyaddheaders