### PR TITLE
Manage the static assets via a class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,11 +27,6 @@ class pulpcore::config {
     mode   => '0775',
   }
 
-  pulpcore::admin { 'collectstatic --noinput':
-    refreshonly => true,
-    subscribe   => Concat['pulpcore settings'],
-  }
-
   selinux::port { 'pulpcore-api-port':
     ensure   => 'present',
     seltype  => 'pulpcore_port_t',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,18 +122,18 @@ class pulpcore (
   Optional[String] $remote_user_environ_name = undef,
   Integer[0] $worker_count = min(8, $facts['processors']['count']),
 ) {
-
   $settings_file = "${config_dir}/settings.py"
 
   contain pulpcore::install
   contain pulpcore::database
   contain pulpcore::config
+  contain pulpcore::static
   contain pulpcore::service
   contain pulpcore::apache
 
   Class['pulpcore::install'] ~> Class['pulpcore::config', 'pulpcore::database', 'pulpcore::service']
-  Class['pulpcore::config'] ~> Class['pulpcore::database', 'pulpcore::service']
-  Class['pulpcore::database'] -> Class['pulpcore::service'] -> Class['pulpcore::apache']
+  Class['pulpcore::config'] ~> Class['pulpcore::database', 'pulpcore::static', 'pulpcore::service']
+  Class['pulpcore::database', 'pulpcore::static'] -> Class['pulpcore::service'] -> Class['pulpcore::apache']
 
   # lint:ignore:spaceship_operator_without_tag
   Class['pulpcore::install']

--- a/manifests/static.pp
+++ b/manifests/static.pp
@@ -1,0 +1,16 @@
+# @summary Manage the static files (assets)
+# @api private
+class pulpcore::static {
+  file { $pulpcore::pulp_static_root:
+    ensure => directory,
+    owner  => $pulpcore::user,
+    group  => $pulpcore::group,
+    mode   => '0755',
+  }
+
+  pulpcore::admin { 'collectstatic --noinput':
+    refreshonly => true,
+    subscribe   => Concat['pulpcore settings'],
+    require     => File[$pulpcore::pulp_static_root],
+  }
+}

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -26,9 +26,13 @@ describe 'pulpcore' do
           is_expected.to contain_file('/var/lib/pulp')
           is_expected.to contain_file('/var/lib/pulp/docroot')
           is_expected.to contain_file('/var/lib/pulp/tmp')
-          is_expected.to contain_pulpcore__admin('collectstatic --noinput')
         end
 
+        it 'sets up static files' do
+          is_expected.to contain_file('/var/lib/pulp/assets')
+          is_expected.to contain_pulpcore__admin('collectstatic --noinput')
+          is_expected.to contain_exec('pulpcore-manager collectstatic --noinput')
+        end
 
         it 'configures the database' do
           is_expected.to contain_class('pulpcore::database')

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -254,11 +254,11 @@ describe 'pulpcore' do
           is_expected.to compile.with_all_deps
           is_expected.to contain_file('/my/custom/directory')
           is_expected.to contain_systemd__unit_file('pulpcore-api.service')
-            .with_content(%r{Environment="PULP_STATIC_ROOT=/my/other/custom/directory"})
           is_expected.to contain_apache__vhost('pulpcore')
             .with_docroot('/my/custom/directory')
           is_expected.to contain_concat__fragment('base')
             .with_content(%r{MEDIA_ROOT = "/my/custom/directory"})
+            .with_content(%r{STATIC_ROOT = "/my/other/custom/directory"})
         end
       end
     end

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -6,7 +6,6 @@ Wants=network-online.target
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
-Environment="PULP_STATIC_ROOT=<%= scope['pulpcore::pulp_static_root'] %>"
 User=<%= scope['pulpcore::user'] %>
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -20,6 +20,7 @@ DATABASES = {
     },
 }
 MEDIA_ROOT = "<%= scope['pulpcore::webserver_static_dir'] %>"
+STATIC_ROOT = "<%= scope['pulpcore::pulp_static_root'] %>"
 REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>


### PR DESCRIPTION
Since 8c66bff5f2146139d2882ef75ac742235fe253b1 the pulpcore-manager command runs as root. On a fresh installation this is fine, but on upgrades the user doesn't own /var/lib/pulp/assets. This explicitly manages the static root.

It is split off to a separate class to better capture the dependencies.  The database doesn't need to refresh due to static files, nor any services.