### PR TITLE
Add Pulpcore repository class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,6 +131,7 @@ class pulpcore (
   contain pulpcore::service
   contain pulpcore::apache
 
+  Anchor <| title == 'pulpcore::repo' |> ~> Class['pulpcore::install']
   Class['pulpcore::install'] ~> Class['pulpcore::config', 'pulpcore::database', 'pulpcore::service']
   Class['pulpcore::config'] ~> Class['pulpcore::database', 'pulpcore::static', 'pulpcore::service']
   Class['pulpcore::database', 'pulpcore::static'] -> Class['pulpcore::service'] -> Class['pulpcore::apache']

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,24 @@
+# Configure the Pulpcore repo
+#
+# @param version
+#   The Pulpcore version to use
+class pulpcore::repo (
+  Pattern['^\d+\.\d+$'] $version = '3.6',
+) {
+  $context = {
+    'version'   => $version,
+    'dist_tag' => "el${facts['os']['release']['major']}",
+  }
+
+  file { '/etc/yum.repos.d/pulpcore.repo':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => epp('pulpcore/repo.epp', $context),
+    notify  => Anchor['pulpcore::repo'],
+  }
+
+  # An anchor is used because it can be collected
+  anchor { 'pulpcore::repo': } # lint:ignore:anchor_resource
+}

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -145,6 +145,16 @@ describe 'pulpcore' do
         end
       end
 
+      context 'with the repo' do
+        let(:pre_condition) { 'include pulpcore::repo' }
+
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_class('pulpcore::repo')
+          is_expected.to contain_file('/etc/yum.repos.d/pulpcore.repo').that_notifies('Class[pulpcore::install]')
+        end
+      end
+
       context 'with custom ports' do
         let :params do
           {

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'pulpcore::repo' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+      it do
+        is_expected.to contain_anchor('pulpcore::repo')
+        is_expected.to contain_file('/etc/yum.repos.d/pulpcore.repo')
+          .with_content(%r{^baseurl=https://yum.theforeman.org/pulpcore/\d+\.\d+/el\d+/\$basearch$})
+          .that_comes_before('Anchor[pulpcore::repo]')
+      end
+    end
+  end
+end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -23,26 +23,14 @@ case $major {
   default: {}
 }
 
-# Defaults to staging, for release, use
-# $baseurl = "https://fedorapeople.org/groups/katello/releases/yum/nightly/pulpcore/el${major}/x86_64/"
-$baseurl = "http://koji.katello.org/releases/yum/katello-nightly/pulpcore/el${major}/x86_64/"
-
-$pulpcore_repo_conf = @("CONF")
-[pulpcore]
-baseurl=${baseurl}
-gpgcheck=0
-module_hotfixes=1
-CONF
-
-file { '/etc/yum.repos.d/pulpcore.repo':
-  ensure  => file,
-  content => $pulpcore_repo_conf,
+class { 'pulpcore::repo':
+  version => fact('pulpcore_version'),
 }
 
 # Needed as a workaround for idempotency
 if $facts['os']['selinux']['enabled'] {
   package { 'pulpcore-selinux':
     ensure  => installed,
-    require => File['/etc/yum.repos.d/pulpcore.repo'],
+    require => Class['pulpcore::repo'],
   }
 }

--- a/templates/repo.epp
+++ b/templates/repo.epp
@@ -1,0 +1,16 @@
+<%- | String[1] $version, String[1] $dist_tag | -%>
+[pulpcore]
+name=Pulpcore <%= $version %>
+baseurl=https://yum.theforeman.org/pulpcore/<%= $version %>/<%= $dist_tag %>/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.theforeman.org/pulpcore/<%= $version %>/GPG-RPM-KEY-pulpcore
+module_hotfixes=1
+
+[pulpcore-source]
+name=Pulpcore <%= $version %> Source
+baseurl=https://yum.theforeman.org/pulpcore/<%= $version %>/<%= $dist_tag %>/source
+enabled=0
+gpgcheck=1
+gpgkey=https://yum.theforeman.org/pulpcore/<%= $version %>/GPG-RPM-KEY-pulpcore
+module_hotfixes=1


### PR DESCRIPTION
This class uses the new yum.theforeman.org repos that are versions per Pulpcore release. This allows easy switching between versions. It also properly sets the GPG key validation.

It does switch acceptance testing from staging repositories to stable repositories. Another implication is that it switches to Pulpcore 3.6 by default. This was chosen since 3.7 is not complete yet.