### PR TITLE
Switch to using a Unix socket bind for API and Content services

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -10,10 +10,10 @@ class pulpcore::apache (
 ) {
   $vhost_priority = $pulpcore::apache_vhost_priority
   $api_path = '/pulp/api/v3'
-  $api_base_url = "http://${pulpcore::api_host}:${pulpcore::api_port}"
+  $api_base_url = "unix://${pulpcore::api_socket_path}|http://${pulpcore::servername}"
   $api_url = "${api_base_url}${api_path}"
   $content_path = '/pulp/content'
-  $content_base_url = "http://${pulpcore::content_host}:${pulpcore::content_port}"
+  $content_base_url = "unix://${pulpcore::content_socket_path}|http://${pulpcore::servername}"
   $content_url = "${content_base_url}${content_path}"
 
   $docroot_directory = {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,17 +37,4 @@ class pulpcore::config {
     mode   => '0750',
   }
 
-  selinux::port { 'pulpcore-api-port':
-    ensure   => 'present',
-    seltype  => 'pulpcore_port_t',
-    protocol => 'tcp',
-    port     => $pulpcore::api_port,
-  }
-
-  selinux::port { 'pulpcore-content-port':
-    ensure   => 'present',
-    seltype  => 'pulpcore_port_t',
-    protocol => 'tcp',
-    port     => $pulpcore::content_port,
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,17 +42,11 @@
 #   apache_https_vhost, this will be used when attaching fragments to those
 #   vhosts. Note that this implies both vhosts need to have the same priority.
 #
-# @param api_host
-#   API service host
+# @param api_socket_path
+#   Path where the Pulpcore API service is listening. This is a unix socket.
 #
-# @param api_port
-#   API service port
-#
-# @param content_host
-#   Content service host
-#
-# @param content_port
-#   Content service port
+# @param content_socket_path
+#   Path where the Pulpcore Content service is listening. This is a unix socket.
 #
 # @param config_dir
 #   Pulp configuration directory. The settings.py file is created under this
@@ -158,10 +152,8 @@ class pulpcore (
   Optional[Stdlib::Absolutepath] $apache_https_ca = undef,
   Optional[Stdlib::Absolutepath] $apache_https_chain = undef,
   String[1] $apache_vhost_priority = '10',
-  Stdlib::Host $api_host = '127.0.0.1',
-  Stdlib::Port $api_port = 24817,
-  Stdlib::Host $content_host = '127.0.0.1',
-  Stdlib::Port $content_port = 24816,
+  Stdlib::Absolutepath $api_socket_path = '/run/pulpcore-api.sock',
+  Stdlib::Absolutepath $content_socket_path = '/run/pulpcore-content.sock',
   String $postgresql_db_name = 'pulpcore',
   String $postgresql_db_user = 'pulp',
   String $postgresql_db_password = extlib::cache_data('pulpcore_cache_data', 'db_password', extlib::random_password(32)),

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,22 @@
 # configure, enable, and start pulpcore services
 # @api private
 class pulpcore::service {
+  include apache
+
+  systemd::unit_file { 'pulpcore-api.socket':
+    content => template('pulpcore/pulpcore-api.socket.erb'),
+    active  => true,
+    enable  => true,
+  }
+
   systemd::unit_file { 'pulpcore-api.service':
     content => template('pulpcore/pulpcore-api.service.erb'),
+    active  => true,
+    enable  => true,
+  }
+
+  systemd::unit_file { 'pulpcore-content.socket':
+    content => template('pulpcore/pulpcore-content.socket.erb'),
     active  => true,
     enable  => true,
   }

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -1,9 +1,10 @@
 [Unit]
-Description=Pulp WSGI Server
-After=network-online.target
-Wants=network-online.target
+Description=Pulp API Server
+After=network.target
+Requires=pulpcore-api.socket
 
 [Service]
+type=notify
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
 User=<%= scope['pulpcore::user'] %>
@@ -11,8 +12,8 @@ Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-api
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.app.wsgi:application \
-          --bind '<%= scope['pulpcore::api_host'] %>:<%= scope['pulpcore::api_port'] %>' \
           --access-logfile -
+ExecReload=/bin/kill -s HUP $MAINPID
 ProtectSystem=full
 PrivateTmp=yes
 PrivateDevices=yes

--- a/templates/pulpcore-api.socket.erb
+++ b/templates/pulpcore-api.socket.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pulp API Server socket
+
+[Socket]
+ListenStream=<%= scope['pulpcore::api_socket_path'] %>
+SocketUser=<%= scope['apache::user'] %>
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -1,9 +1,10 @@
 [Unit]
 Description=Pulp Content App
-After=network-online.target
-Wants=network-online.target
+Requires=pulpcore-content.socket
+After=network.target
 
 [Service]
+type=notify
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS=<%= scope['pulpcore::settings_file'] %>"
 User=<%= scope['pulpcore::user'] %>
@@ -11,11 +12,10 @@ Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-content
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
-          --bind '<%= scope['pulpcore::content_host'] %>:<%= scope['pulpcore::content_port'] %>' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2 \
           --access-logfile -
-
+ExecReload=/bin/kill -s HUP $MAINPID
 SyslogIdentifier=pulpcore-content
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either

--- a/templates/pulpcore-content.socket.erb
+++ b/templates/pulpcore-content.socket.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pulp Content App socket
+
+[Socket]
+ListenStream=<%= scope['pulpcore::content_socket_path'] %>
+SocketUser=<%= scope['apache::user'] %>
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
The use of a Unix socket between the deployed service and the reverse
proxy provides tighter security as the only users who can access the
socket are root and the configured SocketUser. The introduction of
a systemd socket with a ListenStream also provides automatic activation
of the underlying service and safer restarts.

This change is backwards incompatible as it removes the host and port parameters
for the API and Content services in favor of a single bind parameter for each.