### PR TITLE
Support Pulpcore 3.7

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -36,7 +36,10 @@ jobs:
         puppet:
           - "6"
           - "5"
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+        pulpcore_version:
+          - '3.6'
+          - '3.7'
+    name: Puppet ${{ matrix.puppet }} - Pulp ${{ matrix.pulpcore_version }} - ${{ matrix.setfile }}
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -64,3 +67,4 @@ jobs:
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
           BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_FACTER_PULPCORE_VERSION: ${{ matrix.pulpcore_version }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -85,7 +85,10 @@ jobs:
         puppet:
           - "6"
           - "5"
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+        pulpcore_version:
+          - '3.6'
+          - '3.7'
+    name: Puppet ${{ matrix.puppet }} - Pulp ${{ matrix.pulpcore_version }} - ${{ matrix.setfile }}
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -113,3 +116,4 @@ jobs:
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
           BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_FACTER_PULPCORE_VERSION: ${{ matrix.pulpcore_version }}

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,6 @@ gem 'puppet-lint-undef_in_function-check', {"groups"=>["test"]}
 gem 'voxpupuli-test', '~> 1.4'
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
-gem 'voxpupuli-acceptance', '~> 0.2', {"groups"=>["system_tests"]}
+gem 'voxpupuli-acceptance', '~> 0.3', {"groups"=>["system_tests"]}
 
 # vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
+### Pulpcore 3.7
+
+Recommended version.
+
 ### Pulpcore 3.6
 
 Due to the use of libexec wrappers, at least python3-pulpcore 3.6.3-2 must be installed.

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.6',
+  Pattern['^\d+\.\d+$'] $version = '3.7',
 ) {
   $context = {
     'version'   => $version,


### PR DESCRIPTION
This includes the switch to Github actions, but that needs some work. For example, currently in Travis we have a weekly cronjob to notify us of regressions, but it's still missing in the Github actions part.