### PR TITLE
Set docroot to pulpcore_static

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These is also the `cache_dir` which is used to configure [WORKING_DIRECTORY](htt
 
 There is also `chunked_upload_dir` to configure the undocumented `CHUNKED_UPLOAD_DIR`. This directory stores the temporary files used for files uploaded as chunks.
 
-Apache is configured to use an empty directory as docroot (`$apache_docroot`, default `/var/lib/pulp/docroot`). Doing so prevents Apache from bypassing the Pulp content app. When Apache is not managed, this directory is not managed.
+Apache is configured to use an empty directory as docroot (`$apache_docroot`, default `/var/lib/pulp/pulpcore_static`). Doing so prevents Apache from bypassing the Pulp content app. When Apache is not managed, this directory is not managed.
 
 While Pulp can create most of these directories at runtime, they're explicitly managed to set the correct permissions and, if pulpcore-selinux is installed, enforce the correct labels.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,7 @@ class pulpcore (
   Stdlib::Absolutepath $media_root = '/var/lib/pulp/media',
   Stdlib::Absolutepath $static_root = '/var/lib/pulp/assets',
   Pattern['^/.+/$'] $static_url = '/assets/',
-  Stdlib::Absolutepath $apache_docroot = '/var/lib/pulp/docroot',
+  Stdlib::Absolutepath $apache_docroot = '/var/lib/pulp/pulpcore_static',
   Variant[Boolean, String[1]] $apache_http_vhost = true,
   Variant[Boolean, String[1]] $apache_https_vhost = true,
   Optional[Stdlib::Absolutepath] $apache_https_cert = undef,


### PR DESCRIPTION
6a88107e66607dbbbd008d5b2139ed538395f177 changed the docroot to /var/lib/pulp/docroot. While I still think this is a much more descriptive name what it is, Pulp upstream has chosen to go with pulpcore_static. A suggestion to change it was rejected in [7750].

This path will also be included in the SELinux policy so it's important it matches here.

[7750]: https://pulp.plan.io/issues/7750#note-3