### PR TITLE
Set pulpcore_version in .sync.yml for modulesync

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -37,9 +37,9 @@ jobs:
           - "6"
           - "5"
         pulpcore_version:
-          - '3.6'
-          - '3.7'
-    name: Puppet ${{ matrix.puppet }} - Pulp ${{ matrix.pulpcore_version }} - ${{ matrix.setfile }}
+          - "3.6"
+          - "3.7"
+    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }} - Pulpcore version ${{ matrix.pulpcore_version }}
     steps:
       - name: Enable IPv6 on docker
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -86,9 +86,9 @@ jobs:
           - "6"
           - "5"
         pulpcore_version:
-          - '3.6'
-          - '3.7'
-    name: Puppet ${{ matrix.puppet }} - Pulp ${{ matrix.pulpcore_version }} - ${{ matrix.setfile }}
+          - "3.6"
+          - "3.7"
+    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }} - Pulpcore version ${{ matrix.pulpcore_version }}
     steps:
       - name: Enable IPv6 on docker
         run: |

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,11 @@
 ---
-.travis.yml:
-  beaker_sets:
-    - centos7-64
-    - centos8-64
+.github/workflows/acceptance.yml:
+  beaker_fact_matrix:
+    pulpcore_version:
+      - "3.6"
+      - "3.7"
+.github/workflows/cron.yml:
+  beaker_fact_matrix:
+    pulpcore_version:
+      - "3.6"
+      - "3.7"


### PR DESCRIPTION
This uses the [new support in modulesync](https://github.com/theforeman/foreman-installer-modulesync/pull/133) for this. It makes sure a new modulesync wouldn't overwrite the config.

Currently a draft since I haven't figured out the name yet, but I want to see the result of how it is now.