### PR TITLE
Fixes #30436 - add allowed_export_paths to settings.py

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,10 +123,10 @@
 #   Django remote user environment variable
 #
 # @param allowed_import_path
-#   Allowed paths that pulp can use for content view imports, or sync from using file:// protocol
+#   Allowed paths that pulp can use for content imports, or sync from using file:// protocol
 #
 # @param allowed_export_path
-#   Allowed paths that pulp can use for content view exports
+#   Allowed paths that pulp can use for content exports
 #
 # @param worker_count
 #   Number of pulpcore workers. Defaults to 8 or the number of CPU cores, whichever is smaller. Enabling more than 8 workers, even with additional CPU cores

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,7 +177,7 @@ class pulpcore (
   String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(32)),
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
-  Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports'],
+  Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],
   Array[Stdlib::Absolutepath] $allowed_export_path = ['/var/lib/pulp/exports'],
   String[1] $remote_user_environ_name = 'HTTP_REMOTE_USER',
   Integer[0] $worker_count = min(8, $facts['processors']['count']),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class pulpcore (
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
   Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],
-  Array[Stdlib::Absolutepath] $allowed_export_path = ['/var/lib/pulp/exports'],
+  Array[Stdlib::Absolutepath] $allowed_export_path = [],
   String[1] $remote_user_environ_name = 'HTTP_REMOTE_USER',
   Integer[0] $worker_count = min(8, $facts['processors']['count']),
   Boolean $service_enable = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,10 @@
 #   Django remote user environment variable
 #
 # @param allowed_import_path
-#   Allowed paths that pulp can sync from using file:// protocol
+#   Allowed paths that pulp can use for content view imports, or sync from using file:// protocol
+#
+# @param allowed_export_path
+#   Allowed paths that pulp can use for content view exports
 #
 # @param worker_count
 #   Number of pulpcore workers. Defaults to 8 or the number of CPU cores, whichever is smaller. Enabling more than 8 workers, even with additional CPU cores
@@ -174,7 +177,8 @@ class pulpcore (
   String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(32)),
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
-  Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],
+  Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports'],
+  Array[Stdlib::Absolutepath] $allowed_export_path = ['/var/lib/pulp/exports'],
   String[1] $remote_user_environ_name = 'HTTP_REMOTE_USER',
   Integer[0] $worker_count = min(8, $facts['processors']['count']),
   Boolean $service_enable = true,

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -342,7 +342,7 @@ CONTENT
         it do
           is_expected.to compile.with_all_deps
           is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports", "/var/lib/pulp/imports"\]})
+            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
 
         end
       end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -342,7 +342,31 @@ CONTENT
         it do
           is_expected.to compile.with_all_deps
           is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
+            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports", "/var/lib/pulp/imports"\]})
+
+        end
+      end
+
+      context 'with allowed export paths' do
+        let :params do
+          {
+            allowed_export_path: ['/test/path', '/test/path2'],
+          }
+        end
+
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{ALLOWED_EXPORT_PATHS = \["/test/path", "/test/path2"\]})
+
+        end
+      end
+
+      context 'with empty allowed export paths' do
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{ALLOWED_EXPORT_PATHS = \["/var/lib/pulp/exports"\]})
 
         end
       end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -366,7 +366,7 @@ CONTENT
         it do
           is_expected.to compile.with_all_deps
           is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_EXPORT_PATHS = \["/var/lib/pulp/exports"\]})
+            .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
 
         end
       end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -30,6 +30,54 @@ describe 'pulpcore' do
           is_expected.to contain_file('/var/lib/pulp/upload')
         end
 
+        context 'with allowed import paths' do
+          let :params do
+            {
+              allowed_import_path: ['/test/path', '/test/path2'],
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('base')
+              .with_content(%r{ALLOWED_IMPORT_PATHS = \["/test/path", "/test/path2"\]})
+
+          end
+        end
+
+        context 'with empty allowed import paths' do
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('base')
+              .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
+
+          end
+        end
+
+        context 'with allowed export paths' do
+          let :params do
+            {
+              allowed_export_path: ['/test/path', '/test/path2'],
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('base')
+              .with_content(%r{ALLOWED_EXPORT_PATHS = \["/test/path", "/test/path2"\]})
+
+          end
+        end
+
+        context 'with empty allowed export paths' do
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('base')
+              .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
+
+          end
+        end
+
         it 'sets up static files' do
           is_expected.to contain_class('pulpcore::static')
           is_expected.to contain_file('/var/lib/pulp/assets')
@@ -320,54 +368,6 @@ CONTENT
               "            'sslrootcert': '/etc/pki/tls/certs/ca-bundle.crt',",
             ])
           end
-        end
-      end
-
-      context 'with allowed import paths' do
-        let :params do
-          {
-            allowed_import_path: ['/test/path', '/test/path2'],
-          }
-        end
-
-        it do
-          is_expected.to compile.with_all_deps
-          is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/test/path", "/test/path2"\]})
-
-        end
-      end
-
-      context 'with empty allowed import paths' do
-        it do
-          is_expected.to compile.with_all_deps
-          is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
-
-        end
-      end
-
-      context 'with allowed export paths' do
-        let :params do
-          {
-            allowed_export_path: ['/test/path', '/test/path2'],
-          }
-        end
-
-        it do
-          is_expected.to compile.with_all_deps
-          is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_EXPORT_PATHS = \["/test/path", "/test/path2"\]})
-
-        end
-      end
-
-      context 'with empty allowed export paths' do
-        it do
-          is_expected.to compile.with_all_deps
-          is_expected.to contain_concat__fragment('base')
-            .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
-
         end
       end
 

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -38,8 +38,11 @@ REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
     'pulpcore.app.authentication.PulpRemoteUserAuthentication'
 )
 
-<%# This setting whitelists paths that can be used for repository sync with file protocol. Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
+<%# These settings specify paths that can be used for repository sync with file protocol, -%>
+<%# and for content view version import/export. -%>
+<%# Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
 ALLOWED_IMPORT_PATHS = <%= scope['pulpcore::allowed_import_path'] %>
+ALLOWED_EXPORT_PATHS = <%= scope['pulpcore::allowed_export_path'] %>
 
 # Derive HTTP/HTTPS via the X-Forwarded-Proto header set by Apache
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -38,9 +38,6 @@ REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
     'pulpcore.app.authentication.PulpRemoteUserAuthentication'
 )
 
-<%# These settings specify paths that can be used for repository sync with file protocol, -%>
-<%# and for content view version import/export. -%>
-<%# Katello uses the path /var/lib/pulp/sync_imports/ to run tests -%>
 ALLOWED_IMPORT_PATHS = <%= scope['pulpcore::allowed_import_path'] %>
 ALLOWED_EXPORT_PATHS = <%= scope['pulpcore::allowed_export_path'] %>
 


### PR DESCRIPTION
As part of the new content view import/export API work, we need to be able to add import & export paths to `settings.py`:

```python
ALLOWED_IMPORT_PATHS = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports'] # already exists
ALLOWED_EXPORT_PATHS = ['/var/lib/pulp/exports'] # new
```

This PR will be modeled on #79 and adds `ALLOWED_EXPORT_PATHS`.
