### PR TITLE
Set logoutput to on_failure for pulpcore::admin

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -36,5 +36,6 @@ define pulpcore::admin(
     environment => ["PULP_SETTINGS=${pulp_settings}"],
     refreshonly => $refreshonly,
     unless      => $unless,
+    logoutput   => 'on_failure',
   }
 }


### PR DESCRIPTION
We've seen some reports about pulpcore-manager failures but on the next run it passes. Since there is no log output, this is hard to debug. With this change it will log the failures.