### PR TITLE
Drop selinux module dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,6 @@ fixtures:
     extlib:           'https://github.com/voxpupuli/puppet-extlib'
     postgresql:       'https://github.com/puppetlabs/puppetlabs-postgresql'
     redis:            'https://github.com/voxpupuli/puppet-redis'
-    selinux:          'https://github.com/voxpupuli/puppet-selinux'
     selinux_core:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'

--- a/metadata.json
+++ b/metadata.json
@@ -33,10 +33,6 @@
     {
       "name": "puppet/extlib",
       "version_requirement": ">= 3.0.0 < 6.0.0"
-    },
-    {
-      "name": "puppet/selinux",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -235,7 +235,7 @@ describe 'pulpcore' do
           is_expected.not_to contain_file('/var/lib/pulp/pulpcore_static')
           is_expected.not_to contain_apache__vhost('pulpcore')
           is_expected.not_to contain_apache__vhost('pulpcore-https')
-          is_expected.not_to contain_selinux__boolean('httpd_can_network_connect')
+          is_expected.not_to contain_selboolean('httpd_can_network_connect')
         end
       end
 


### PR DESCRIPTION
04b9f5f4fbcaafd87c6ea056b9b499197739c7c4 stopped using selinux::port which means the module is no longer used.

Also corrects an assertion around selboolean. a60df532a95dbb3bf951aaf10b85f9b31ba3e635 changed from selinux::boolean to the raw selboolean. While it was true that the resource was never contained, it was no longer correctly testing the logic.