### PR TITLE
Allow configuring the registry url for the container plugin

### DIFF
--- a/manifests/plugin/container.pp
+++ b/manifests/plugin/container.pp
@@ -8,7 +8,15 @@
 class pulpcore::plugin::container (
   String $location_prefix = '/pulpcore_registry',
   String $registry_version_path = '/v2/',
+  String $registry_base_url = '',
 ) {
+
+  if $registry_base_url == '' {
+    $_registry_base_url = $pulpcore::apache::api_base_url
+  } else {
+    $_registry_base_url = $registry_base_url
+  }
+
   $context = {
     'directories' => [
       {
@@ -16,7 +24,7 @@ class pulpcore::plugin::container (
         'path'            => "${location_prefix}${registry_version_path}",
         'proxy_pass'      => [
           {
-            'url' => "${pulpcore::apache::api_base_url}${registry_version_path}",
+            'url' => "${_registry_base_url}${registry_version_path}",
           },
         ],
         'request_headers' => [

--- a/spec/classes/plugin_container_spec.rb
+++ b/spec/classes/plugin_container_spec.rb
@@ -3,19 +3,72 @@ require 'spec_helper'
 describe 'pulpcore::plugin::container' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
-      let(:pre_condition) { 'include pulpcore' }
+      describe 'default params' do
+        let(:facts) { os_facts }
+        let(:pre_condition) { 'include pulpcore' }
 
-      it 'configures the plugin' do
-        is_expected.to compile.with_all_deps
-        is_expected.to contain_pulpcore__plugin('container')
-          .that_subscribes_to('Class[Pulpcore::Install]')
-          .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
-        is_expected.to contain_package('python3-pulp-container')
-        is_expected.to contain_concat__fragment('plugin-container').with_content("\n# container plugin settings\nTOKEN_AUTH_DISABLED=True")
-        is_expected.to contain_pulpcore__apache__fragment('plugin-container')
-        is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-plugin-container')
-        is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-container')
+        it 'configures the plugin' do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_pulpcore__plugin('container')
+            .that_subscribes_to('Class[Pulpcore::Install]')
+            .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
+          is_expected.to contain_package('python3-pulp-container')
+          is_expected.to contain_concat__fragment('plugin-container').with_content("\n# container plugin settings\nTOKEN_AUTH_DISABLED=True")
+          is_expected.to contain_pulpcore__apache__fragment('plugin-container')
+          is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-plugin-container')
+          is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-container')
+            .with_content(
+<<CONTENT
+
+  <Location "/pulpcore_registry/v2/">
+    RequestHeader unset REMOTE_USER
+    RequestHeader set REMOTE_USER "%{SSL_CLIENT_S_DN_CN}s" env=SSL_CLIENT_S_DN_CN
+    ProxyPass unix:///run/pulpcore-api.sock|http://foo.example.com/v2/
+    ProxyPassReverse unix:///run/pulpcore-api.sock|http://foo.example.com/v2/
+  </Location>
+
+  ProxyPass /pulp/container/ unix:///run/pulpcore-content.sock|http://foo.example.com/pulp/container/
+  ProxyPassReverse /pulp/container/ unix:///run/pulpcore-content.sock|http://foo.example.com/pulp/container/
+CONTENT
+            )
+        end
+      end
+
+      describe 'set registry base url' do
+        let(:facts) { os_facts }
+        let(:pre_condition) { 'include pulpcore' }
+
+        let(:params) do
+          {
+            registry_base_url: 'unix:///run/test.sock|http://example.com'
+          }
+        end
+
+        it 'configures the plugin' do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_pulpcore__plugin('container')
+            .that_subscribes_to('Class[Pulpcore::Install]')
+            .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
+          is_expected.to contain_package('python3-pulp-container')
+          is_expected.to contain_concat__fragment('plugin-container').with_content("\n# container plugin settings\nTOKEN_AUTH_DISABLED=True")
+          is_expected.to contain_pulpcore__apache__fragment('plugin-container')
+          is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-plugin-container')
+          is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-container')
+            .with_content(
+<<CONTENT
+
+  <Location "/pulpcore_registry/v2/">
+    RequestHeader unset REMOTE_USER
+    RequestHeader set REMOTE_USER "%{SSL_CLIENT_S_DN_CN}s" env=SSL_CLIENT_S_DN_CN
+    ProxyPass unix:///run/test.sock|http://example.com/v2/
+    ProxyPassReverse unix:///run/test.sock|http://example.com/v2/
+  </Location>
+
+  ProxyPass /pulp/container/ unix:///run/pulpcore-content.sock|http://foo.example.com/pulp/container/
+  ProxyPassReverse /pulp/container/ unix:///run/pulpcore-content.sock|http://foo.example.com/pulp/container/
+CONTENT
+            )
+        end
       end
     end
   end


### PR DESCRIPTION
Katello needs to be able to set the registry URL to an API end
point on the Foreman server to control auth for the registry. This
defaults to the Pulpcore API but provides a parameter to configure
this to allow pointing to the Katello endpoint instead.