### PR TITLE
Increase the secret key size to 50 chars

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,7 +174,7 @@ class pulpcore (
   Optional[Stdlib::Absolutepath] $postgresql_db_ssl_cert = undef,
   Optional[Stdlib::Absolutepath] $postgresql_db_ssl_key = undef,
   Optional[Stdlib::Absolutepath] $postgresql_db_ssl_root_ca = undef,
-  String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(32)),
+  String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(50)),
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
   Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],


### PR DESCRIPTION
This is recommended by Django and generates a warning about this when doing production checks. Since it's using cached data, this doesn't affect upgrading users.