### PR TITLE
Allow setting parameters on the API and Content Apache proxy

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -7,6 +7,8 @@ class pulpcore::apache (
   Hash[String, Any] $http_vhost_options = {},
   Hash[String, Any] $https_vhost_options = {},
   Enum['none', 'optional', 'require', 'optional_no_ca'] $ssl_verify_client = 'optional',
+  Hash $content_proxy_params = {'timeout' => '600'},
+  Hash $api_proxy_params = {'timeout' => '600'},
 ) {
   $vhost_priority = $pulpcore::apache_vhost_priority
   $api_path = '/pulp/api/v3'
@@ -27,7 +29,8 @@ class pulpcore::apache (
     'provider'        => 'location',
     'proxy_pass'      => [
       {
-        'url' => $content_url,
+        'url'    => $content_url,
+        'params' => $content_proxy_params,
       },
     ],
     'request_headers' => [
@@ -44,7 +47,8 @@ class pulpcore::apache (
     'provider'        => 'location',
     'proxy_pass'      => [
       {
-        'url' => $api_url,
+        'url'    => $api_url,
+        'params' => $api_proxy_params,
       },
     ],
     'request_headers' => [

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -64,7 +64,10 @@ describe 'pulpcore' do
               {
                 'path'            => '/pulp/content',
                 'provider'        => 'location',
-                'proxy_pass'      => [{'url'  => 'unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content'}],
+                'proxy_pass'      => [{
+                  'url'    => 'unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content',
+                  'params' => {'timeout' => '600'},
+                }],
                 'request_headers' => [
                   'unset X-CLIENT-CERT',
                   'set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT',
@@ -82,7 +85,10 @@ describe 'pulpcore' do
               {
                 'path'            => '/pulp/content',
                 'provider'        => 'location',
-                'proxy_pass'      => [{'url'  => 'unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content'}],
+                'proxy_pass'      => [{
+                  'url'    => 'unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content',
+                  'params' => {'timeout' => '600'},
+                }],
                 'request_headers' => [
                   'unset X-CLIENT-CERT',
                   'set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT',
@@ -91,7 +97,10 @@ describe 'pulpcore' do
               {
                 'path'            => '/pulp/api/v3',
                 'provider'        => 'location',
-                'proxy_pass'      => [{'url'=>'unix:///run/pulpcore-api.sock|http://pulpcore-api/pulp/api/v3'}],
+                'proxy_pass'      => [{
+                  'url'    => 'unix:///run/pulpcore-api.sock|http://pulpcore-api/pulp/api/v3',
+                  'params' => {'timeout' => '600'},
+                }],
                 'request_headers' => [
                   'unset REMOTE_USER',
                   'set REMOTE_USER "%{SSL_CLIENT_S_DN_CN}s" env=SSL_CLIENT_S_DN_CN',
@@ -270,7 +279,7 @@ describe 'pulpcore' do
   <Location "/pulp/content">
     RequestHeader unset X-CLIENT-CERT
     RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
-    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
     ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
   </Location>
 CONTENT
@@ -287,14 +296,14 @@ CONTENT
   <Location "/pulp/content">
     RequestHeader unset X-CLIENT-CERT
     RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
-    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
     ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
   </Location>
 
   <Location "/pulp/api/v3">
     RequestHeader unset REMOTE_USER
     RequestHeader set REMOTE_USER "%{SSL_CLIENT_S_DN_CN}s" env=SSL_CLIENT_S_DN_CN
-    ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api/pulp/api/v3
+    ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api/pulp/api/v3 timeout=600
     ProxyPassReverse unix:///run/pulpcore-api.sock|http://pulpcore-api/pulp/api/v3
   </Location>
 

--- a/templates/apache-fragment.epp
+++ b/templates/apache-fragment.epp
@@ -40,7 +40,7 @@
     <%-   $directory['proxy_pass'].each |$proxy| { -%>
     ProxyPass <%= $proxy['url'] -%>
     <%-     if $proxy['params'] { -%>
-    <%-       $proxy['params'].sort.each |$key, $value| { -%> <%= $key %>=<%= $value -%><%- } -%>
+    <%-       $proxy['params'].keys.sort.each |$key| { -%> <%= ' ' %><%= $key %>=<%= $proxy['params'][$key] -%><%- } -%>
     <%-     } %>
     <%-     if $proxy['reverse_urls'] { -%>
     <%-       $proxy['reverse_urls'].each |$reverse_url| { -%>


### PR DESCRIPTION
Adds a default timeout of 5 minutes to the parameters to address
issues seen when syncing from a Pulp 3 to a Pulp 3 mirror.

The default proxy timeout is 60 seconds, and we have seen in nightly, proxy syncing fail right at the one minute mark. This is a bit of tuning problem so I figured let's start with a higher default of 5 minutes and monitor.