### PR TITLE
Add proxy params to plugin Pulp 2 content routes

### DIFF
--- a/manifests/plugin/deb.pp
+++ b/manifests/plugin/deb.pp
@@ -11,7 +11,8 @@ class pulpcore::plugin::deb (
           'path'            => '/pulp/deb',
           'proxy_pass'      => [
             {
-              'url' => $pulpcore::apache::content_url,
+              'url'    => $pulpcore::apache::content_url,
+              'params' => $pulpcore::apache::content_proxy_params,
             },
           ],
           'request_headers' => [

--- a/manifests/plugin/file.pp
+++ b/manifests/plugin/file.pp
@@ -12,7 +12,8 @@ class pulpcore::plugin::file (
           'path'            => '/pulp/isos',
           'proxy_pass'      => [
             {
-              'url' => $pulpcore::apache::content_url,
+              'url'    => $pulpcore::apache::content_url,
+              'params' => $pulpcore::apache::content_proxy_params,
             },
           ],
           'request_headers' => [

--- a/manifests/plugin/rpm.pp
+++ b/manifests/plugin/rpm.pp
@@ -12,7 +12,8 @@ class pulpcore::plugin::rpm (
           'path'            => '/pulp/repos',
           'proxy_pass'      => [
             {
-              'url' => $pulpcore::apache::content_url,
+              'url'    => $pulpcore::apache::content_url,
+              'params' => $pulpcore::apache::content_proxy_params,
             },
           ],
           'request_headers' => [

--- a/spec/classes/plugin_deb_spec.rb
+++ b/spec/classes/plugin_deb_spec.rb
@@ -28,7 +28,29 @@ describe 'pulpcore::plugin::deb' do
             is_expected.to compile.with_all_deps
             is_expected.to contain_pulpcore__apache__fragment('plugin-deb')
             is_expected.to contain_apache__vhost__fragment('pulpcore-http-plugin-deb')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/deb">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
             is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-deb')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/deb">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
           end
         end
       end

--- a/spec/classes/plugin_file_spec.rb
+++ b/spec/classes/plugin_file_spec.rb
@@ -18,6 +18,39 @@ describe 'pulpcore::plugin::file' do
             .that_subscribes_to('Class[Pulpcore::Install]')
             .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
         end
+
+        context 'with pulp2 content route' do
+          let(:params) { { use_pulp2_content_route: true } }
+
+          it 'contains the Apache fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_pulpcore__apache__fragment('plugin-file')
+            is_expected.to contain_apache__vhost__fragment('pulpcore-http-plugin-file')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/isos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
+            is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-file')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/isos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
+          end
+        end
       end
     end
   end

--- a/spec/classes/plugin_rpm_spec.rb
+++ b/spec/classes/plugin_rpm_spec.rb
@@ -28,7 +28,29 @@ describe 'pulpcore::plugin::rpm' do
             is_expected.to compile.with_all_deps
             is_expected.to contain_pulpcore__apache__fragment('plugin-rpm')
             is_expected.to contain_apache__vhost__fragment('pulpcore-http-plugin-rpm')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/repos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
             is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-rpm')
+              .with_content(
+<<CONTENT
+
+  <Location "/pulp/repos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content timeout=600
+    ProxyPassReverse unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/content
+  </Location>
+CONTENT
+              )
           end
         end
       end


### PR DESCRIPTION
For legacy content access, the old Pulp 2 routes are used and proxy directly to the content app rather than redirecting. Thus, they also need to have the proxy parameters such as timeout specified on them.