### PR TITLE
Pulpcore 3.9 requires upload to be under media

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,7 +149,7 @@ class pulpcore (
   Stdlib::Absolutepath $user_home = '/var/lib/pulp',
   Stdlib::Absolutepath $config_dir = '/etc/pulp',
   Stdlib::Absolutepath $cache_dir = '/var/lib/pulp/tmp',
-  Stdlib::Absolutepath $chunked_upload_dir = '/var/lib/pulp/upload',
+  Stdlib::Absolutepath $chunked_upload_dir = '/var/lib/pulp/media/upload',
   Stdlib::Absolutepath $media_root = '/var/lib/pulp/media',
   Stdlib::Absolutepath $static_root = '/var/lib/pulp/assets',
   Pattern['^/.+/$'] $static_url = '/assets/',

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -30,7 +30,7 @@ describe 'pulpcore' do
           is_expected.to contain_file('/var/lib/pulp/media')
           is_expected.to contain_file('/var/lib/pulp/pulpcore_static')
           is_expected.to contain_file('/var/lib/pulp/tmp')
-          is_expected.to contain_file('/var/lib/pulp/upload')
+          is_expected.to contain_file('/var/lib/pulp/media/upload')
         end
 
         it 'sets up static files' do


### PR DESCRIPTION
This issue can be worked around until Pulpcore 3.10 fixes it by moving the chunked uploads directory to be under `/var/lib/pulp/media` (the `MEDIA_ROOT`).

This is necessary for Katello to upgrade to Pulpcore 3.9.