### PR TITLE
Support Pulp 3.9, drop earlier versions

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -37,8 +37,7 @@ jobs:
           - "6"
           - "5"
         pulpcore_version:
-          - '3.6'
-          - '3.7'
+          - '3.9'
     name: Puppet ${{ matrix.puppet }} - Pulp ${{ matrix.pulpcore_version }} - ${{ matrix.setfile }}
     steps:
       - name: Enable IPv6 on docker

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.7
+### Pulpcore 3.9
 
-Recommended version.
-
-### Pulpcore 3.6
-
-Due to the use of libexec wrappers, at least python3-pulpcore 3.6.3-2 must be installed.
+Recommended version. At least version 3.9.1 should be used.
 
 ## Installation layout
 
@@ -29,8 +25,6 @@ The media root (default `/var/lib/pulp/media`) refers to the [MEDIA_ROOT setting
 There are also the [STATIC_ROOT](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-STATIC_ROOT) and [STATIC_URL](https://docs.djangoproject.com/en/2.2/ref/settings/#static-url) settings. These serve the static assets used by Pulp. This includes CSS and Javascript for the HTML pages. They're not needed for the application to function, but make browsing the API more convenient.
 
 These is also the `cache_dir` which is used to configure [WORKING_DIRECTORY](https://docs.pulpproject.org/settings.html#working-directory) and [FILE_UPLOAD_TEMP_DIR](https://docs.djangoproject.com/en/2.2/ref/settings/#file-upload-temp-dir). This defaults to `/var/lib/pulp/tmp`. It is strongly recommended that this is on the same filesystem as `MEDIA_ROOT`.
-
-There is also `chunked_upload_dir` to configure the undocumented `CHUNKED_UPLOAD_DIR`. This directory stores the temporary files used for files uploaded as chunks.
 
 Apache is configured to use an empty directory as docroot (`$apache_docroot`, default `/var/lib/pulp/pulpcore_static`). Doing so prevents Apache from bypassing the Pulp content app. When Apache is not managed, this directory is not managed.
 
@@ -48,8 +42,7 @@ This results into the following structure, using `tree -pug`:
             ├── [drwxr-xr-x pulp     pulp    ]  assets ($static_root)
             ├── [drwxr-xr-x pulp     pulp    ]  pulpcore_static ($apache_docroot)
             ├── [drwxr-x--- pulp     pulp    ]  media ($media_root)
-            ├── [drwxr-x--- pulp     pulp    ]  tmp ($cache_dir)
-            └── [drwxr-x--- pulp     pulp    ]  upload ($chunked_upload_dir)
+            └── [drwxr-x--- pulp     pulp    ]  tmp ($cache_dir)
 ```
 
 ## Service setup

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,7 +30,7 @@ class pulpcore::config {
     mode   => '0775',
   }
 
-  file { [$pulpcore::cache_dir, $pulpcore::chunked_upload_dir, $pulpcore::media_root]:
+  file { [$pulpcore::cache_dir, $pulpcore::media_root]:
     ensure => directory,
     owner  => $pulpcore::user,
     group  => $pulpcore::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,10 +56,6 @@
 #   Pulp cache directory. This is used to configure WORKING_DIRECTORY and
 #   FILE_UPLOAD_TEMP_DIR.
 #
-# @param chunked_upload_dir
-#   Pulp chunked upload directory. This is used to configure CHUNKED_UPLOAD_DIR
-#   and is used by Pulp to temporarily store files that are uploaded in chunks.
-#
 # @param apache_docroot
 #   Root directory for the Apache vhost. Only created if the Apache vhost is
 #   managed by this module.
@@ -149,7 +145,6 @@ class pulpcore (
   Stdlib::Absolutepath $user_home = '/var/lib/pulp',
   Stdlib::Absolutepath $config_dir = '/etc/pulp',
   Stdlib::Absolutepath $cache_dir = '/var/lib/pulp/tmp',
-  Stdlib::Absolutepath $chunked_upload_dir = '/var/lib/pulp/upload',
   Stdlib::Absolutepath $media_root = '/var/lib/pulp/media',
   Stdlib::Absolutepath $static_root = '/var/lib/pulp/assets',
   Pattern['^/.+/$'] $static_url = '/assets/',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.7',
+  Pattern['^\d+\.\d+$'] $version = '3.9',
 ) {
   $context = {
     'version'   => $version,

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -30,7 +30,6 @@ describe 'pulpcore' do
           is_expected.to contain_file('/var/lib/pulp/media')
           is_expected.to contain_file('/var/lib/pulp/pulpcore_static')
           is_expected.to contain_file('/var/lib/pulp/tmp')
-          is_expected.to contain_file('/var/lib/pulp/upload')
         end
 
         it 'sets up static files' do

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -28,7 +28,6 @@ STATIC_ROOT = "<%= scope['pulpcore::static_root'] %>"
 STATIC_URL = "<%= scope['pulpcore::static_url'] %>"
 FILE_UPLOAD_TEMP_DIR = "<%= scope['pulpcore::cache_dir'] %>"
 WORKING_DIRECTORY = "<%= scope['pulpcore::cache_dir'] %>"
-CHUNKED_UPLOAD_DIR = "<%= scope['pulpcore::chunked_upload_dir'] %>"
 
 REMOTE_USER_ENVIRON_NAME = '<%= scope['pulpcore::remote_user_environ_name'] %>'
 AUTHENTICATION_BACKENDS = ['pulpcore.app.authentication.PulpNoCreateRemoteUserBackend']


### PR DESCRIPTION
Pulp 3.9 changes CHUNKED_UPLOAD_DIR from an absolute path to a relative path. It must be within MEDIA_ROOT and there's no need to manage it.  Pulp defaults are correct and overriding it is not recommended upstream.

This does rely on a fix in Pulpcore 3.9.1 which is currently [being worked on](https://github.com/pulp/pulpcore/pull/1078). Hence why this is a draft.

Technically older versions will continue to work but the upload directory may not exist and the pulp user may not have permission to create it. Rather than documenting these, it's chosen to only support the latest version. This also saves CI resources.