### PR TITLE
Support camptocamp/systemd 3.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,4 +14,9 @@ fixtures:
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'
     systemd:
       repo: 'https://github.com/camptocamp/puppet-systemd'
+      puppet_version: '>= 6.1.0'
+  forge_modules:
+    systemd:
+      repo: 'camptocamp/systemd'
       ref: '2.12.0'
+      puppet_version: '< 6.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,4 @@ jobs:
         env:
           BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
           BEAKER_setfile: ${{ matrix.setfile.value }}
+          PUPPET_VERSION: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: development:test:release
+      PUPPET_VERSION: "${{ matrix.puppet.value }}.0"
     strategy:
       fail-fast: false
       matrix:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -37,11 +37,23 @@ class pulpcore::service {
     content => template('pulpcore/pulpcore-worker@.service.erb'),
   }
 
+  # In camptocamp/systemd 3.0.0 support for Puppet < 6.1.0 was dropped.
+  # This means there is no single daemon-reload class anymore. This also means
+  # there is no more relation that ensures all services are loaded prior to running them.
+  $metadata = load_module_metadata('systemd')
+  if SemVer($metadata['version']) >= SemVer('3.0.0') {
+    Systemd::Unit_file['pulpcore-api.socket']  -> Systemd::Unit_file['pulpcore-api.service']
+    Systemd::Unit_file['pulpcore-content.socket']  -> Systemd::Unit_file['pulpcore-content.service']
+    $reload_require = undef
+  } else {
+    $reload_require = Class['systemd::systemctl::daemon_reload']
+  }
+
   Integer[1, $pulpcore::worker_count].each |$n| {
     service { "pulpcore-worker@${n}.service":
       ensure    => $pulpcore::service_ensure,
       enable    => $pulpcore::service_enable,
-      require   => Class['systemd::systemctl::daemon_reload'],
+      require   => $reload_require,
       subscribe => Systemd::Unit_file['pulpcore-worker@.service'],
     }
   }
@@ -53,7 +65,7 @@ class pulpcore::service {
         service { $worker:
           ensure  => false,
           enable  => false,
-          require => [Systemd::Unit_file['pulpcore-worker@.service'], Class['systemd::systemctl::daemon_reload']],
+          require => [Systemd::Unit_file['pulpcore-worker@.service'], $reload_require],
         }
       }
     }

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -118,6 +118,10 @@ describe 'pulpcore' do
 
         it 'configures services' do
           is_expected.to contain_class('pulpcore::service')
+          is_expected.to contain_systemd__unit_file('pulpcore-api.socket').that_comes_before('Systemd::Unit_file[pulpcore-api.service]')
+          is_expected.to contain_systemd__unit_file('pulpcore-api.service').that_requires('Systemd::Unit_file[pulpcore-api.socket]')
+          is_expected.to contain_systemd__unit_file('pulpcore-content.socket').that_comes_before('Systemd::Unit_file[pulpcore-content.service]')
+          is_expected.to contain_systemd__unit_file('pulpcore-content.service').that_requires('Systemd::Unit_file[pulpcore-content.socket]')
           is_expected.to contain_systemd__unit_file('pulpcore-resource-manager.service')
           is_expected.to contain_systemd__unit_file('pulpcore-worker@.service')
           is_expected.to contain_service("pulpcore-worker@1.service").with_ensure(true)


### PR DESCRIPTION
The development branch of camptocamp/systemd has dropped support for Puppet 5 but for now we keep our modules compatible with it. This allows us to remain compatible with both.

Technically it's 6.1.0 that automatically does daemon reloads if needed.