### PR TITLE
Pin camptocamp/systemd to 2.12.0 in testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,4 +12,6 @@ fixtures:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'
-    systemd:          'https://github.com/camptocamp/puppet-systemd'
+    systemd:
+      repo: 'https://github.com/camptocamp/puppet-systemd'
+      ref: '2.12.0'


### PR DESCRIPTION
Git master has dropped daemon reloading code which we currently depend on. This pins to the latest released version. I tried to support both, but currently there's no way to distinguish 2.x and 3.x.

https://github.com/theforeman/puppet-pulpcore/pull/176 contains those efforts. https://github.com/camptocamp/puppet-systemd/pull/186 would allow that to work (though there are some other issues).