### PR TITLE
Refs #32112 - Match upstream pulp default api service worker timeout

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,9 @@
 #   Number of pulpcore-api service workers for gunicorn to use.
 #   Modifying this parameter should be done incrementally with benchmarking at each step to determine an optimal value for your deployment.
 #
+# @param content_service_worker_timeout
+#   Timeout in seconds of the pulpcore-content gunicorn workers.
+#
 # @param api_service_worker_timeout
 #   Timeout in seconds of the pulpcore-api gunicorn workers.
 #
@@ -191,6 +194,7 @@ class pulpcore (
   Boolean $service_ensure = true,
   Integer[0] $content_service_worker_count = (2*min(8, $facts['processors']['count']) + 1),
   Integer[0] $api_service_worker_count = 1,
+  Integer[0] $content_service_worker_timeout = 90,
   Integer[0] $api_service_worker_timeout = 90,
 ) {
   $settings_file = "${config_dir}/settings.py"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,7 +191,7 @@ class pulpcore (
   Boolean $service_ensure = true,
   Integer[0] $content_service_worker_count = (2*min(8, $facts['processors']['count']) + 1),
   Integer[0] $api_service_worker_count = 1,
-  Integer[0] $api_service_worker_timeout = 60,
+  Integer[0] $api_service_worker_timeout = 90,
 ) {
   $settings_file = "${config_dir}/settings.py"
 

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -12,6 +12,7 @@ Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-content
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
+          --timeout <%= scope['pulpcore::content_service_worker_timeout'] %> \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w <%= scope['pulpcore::content_service_worker_count'] %> \
           --access-logfile -


### PR DESCRIPTION
Upstream pulp_installer uses a default gunicorn worker timeout of 90 seconds[1] for both the content service (which we previously did not configure) and the api service (which we configured to 60 seconds)

[1] https://github.com/pulp/pulp_installer/blob/645887df342f3d06a2aa8ec90740bd41179331c7/roles/pulp_content/templates/pulpcore-content.service.j2#L24