### PR TITLE
Fixes #32309 - pulpcore-manager fails from certain directories

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -23,6 +23,9 @@
 # @param timeout
 #   The command should timeout after so many seconds.
 #
+# @param working_dir
+#   The directory to run pulpcore-manager from.
+#
 # @see exec
 define pulpcore::admin(
   String $command = $title,
@@ -32,11 +35,13 @@ define pulpcore::admin(
   String $user = $pulpcore::user,
   Stdlib::Absolutepath $pulp_settings = $pulpcore::settings_file,
   Optional[Integer[0]] $timeout = undef,
+  Stdlib::Absolutepath $working_dir = $pulpcore::user_home,
 ) {
   Concat <| title == 'pulpcore settings' |>
   -> exec { "pulpcore-manager ${command}":
     user        => $user,
     path        => $path,
+    cwd         => $working_dir,
     environment => ["PULP_SETTINGS=${pulp_settings}"],
     refreshonly => $refreshonly,
     unless      => $unless,

--- a/spec/defines/admin_spec.rb
+++ b/spec/defines/admin_spec.rb
@@ -11,6 +11,7 @@ describe 'pulpcore::admin' do
           {
             pulp_settings: '/etc/pulpcore/settings.py',
             user: 'pulpcore',
+            working_dir: '/var/lib/pulp'
           }
         end
 
@@ -22,6 +23,7 @@ describe 'pulpcore::admin' do
               .with_environment(['PULP_SETTINGS=/etc/pulpcore/settings.py'])
               .with_refreshonly(false)
               .with_unless(nil)
+              .with_cwd('/var/lib/pulp')
           end
         end
 


### PR DESCRIPTION
Sets a specific directory for pulpcore-manager to be called from.