### PR TITLE
Refs #32383: Configurable client certificate authentication to Pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,6 +152,9 @@
 # @param api_service_worker_timeout
 #   Timeout in seconds of the pulpcore-api gunicorn workers.
 #
+# @param api_client_auth_cn_map
+#   Mapping of certificate common name and Pulp user to authenticate to Pulp API.
+#
 # @example Default configuration
 #   include pulpcore
 #
@@ -200,6 +203,7 @@ class pulpcore (
   Integer[0] $api_service_worker_count = 1,
   Integer[0] $content_service_worker_timeout = 90,
   Integer[0] $api_service_worker_timeout = 90,
+  Hash[String[1], String[1]] $api_client_auth_cn_map = {},
 ) {
   $settings_file = "${config_dir}/settings.py"
 


### PR DESCRIPTION
…o Pulp as admin

Require a client certificate to be presented with a CN that matches
the supplied auth CN. If this is present, set the REMOTE_USER to
admin to pass along to Pulp. This changes from having to generate
aclient certificate with a valid user (e.g. admin) as the CN
to allowing to use a client certificate generated with a more standard
CN (e.g. FQDN) and act as the admin user.

Example usage:

```
class { 'pulpcore':
  api_client_auth_cn => $foreman_host
}
```

Questions:

 * This would allow us to drop the special purpose pulp_client certificates we generate today. Do we want to go this route?
 * Is this the best way implement how we enable this and configure it?
 * This forces all API paths to be behind authentication now. The `/pulp/api/v3/status/` does not require authentication by Pulp. Do we want an exception for that route? If so, how do we idenitfy that path in the Apache config to skip the require?