### PR TITLE
Fixes #32309 - Run admin commands from Pulp's home

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - uses: actions/cache@v2

--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -20,6 +20,9 @@
 # @param pulp_settings
 #   Root directory for static content
 #
+# @param working_dir
+#   The directory to run pulpcore-manager from.
+#
 # @see exec
 define pulpcore::admin(
   String $command = $title,
@@ -28,11 +31,13 @@ define pulpcore::admin(
   Array[Stdlib::Absolutepath] $path = ['/usr/bin'],
   String $user = $pulpcore::user,
   Stdlib::Absolutepath $pulp_settings = $pulpcore::settings_file,
+  Stdlib::Absolutepath $working_dir = $pulpcore::user_home,
 ) {
   Concat <| title == 'pulpcore settings' |>
   -> exec { "pulpcore-manager ${command}":
     user        => $user,
     path        => $path,
+    cwd         => $working_dir,
     environment => ["PULP_SETTINGS=${pulp_settings}"],
     refreshonly => $refreshonly,
     unless      => $unless,

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -110,6 +110,7 @@ class pulpcore::apache (
         ssl_chain         => $pulpcore::apache_https_chain,
         ssl_ca            => $pulpcore::apache_https_ca,
         ssl_verify_client => $ssl_verify_client,
+        ssl_options       => ['+StdEnvVars', '+ExportCertData'],
         *                 => $https_vhost_options,
       }
     }

--- a/spec/defines/admin_spec.rb
+++ b/spec/defines/admin_spec.rb
@@ -11,6 +11,7 @@ describe 'pulpcore::admin' do
           {
             pulp_settings: '/etc/pulpcore/settings.py',
             user: 'pulpcore',
+            working_dir: '/var/lib/pulp'
           }
         end
 
@@ -22,6 +23,7 @@ describe 'pulpcore::admin' do
               .with_environment(['PULP_SETTINGS=/etc/pulpcore/settings.py'])
               .with_refreshonly(false)
               .with_unless(nil)
+              .with_cwd('/var/lib/pulp')
           end
         end
 


### PR DESCRIPTION
* Dynaconf seems to always be using the current directory. As such, the
  cwd could be a directory that is unreadable by the pulp user.  Pulp's
  user home must always be readable by the pulp user.

(cherry picked from commit 951a2f823cf57986623329af54f7d060d256e757)