### PR TITLE
Pin camptocamp/systemd to 2.12.0 in testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,4 +12,6 @@ fixtures:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'
-    systemd:          'https://github.com/camptocamp/puppet-systemd'
+    systemd:
+      repo: 'https://github.com/camptocamp/puppet-systemd'
+      ref: '2.12.0'


### PR DESCRIPTION
Git master has dropped daemon reloading code which we currently depend
on. This pins to the latest released version. I tried to support both,
but currently there's no way to distinguish 2.x and 3.x.

(cherry picked from commit 30d4ecacdc4a98db88e08c2efb5a387b31e7aa53)