### PR TITLE
Fixes #32622: Include StdEnvVars, ExportCertData SSL options in Apache

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -123,6 +123,7 @@ class pulpcore::apache (
         ssl_chain         => $pulpcore::apache_https_chain,
         ssl_ca            => $pulpcore::apache_https_ca,
         ssl_verify_client => $ssl_verify_client,
+        ssl_options       => ['+StdEnvVars', '+ExportCertData'],
         *                 => $https_vhost_options,
       }
     }


### PR DESCRIPTION
When deploying a stand-alone vhost, Pulp needs these SSL options
set in order for X-CLIENT-CERT to be set.

This fixes an issue for content proxies with Red Hat based content that receive a 403 currently. This should be backported to at least Foreman 2.3.