### PR TITLE
Support camptocamp/systemd 3.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,6 +12,4 @@ fixtures:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'
-    systemd:
-      repo: 'https://github.com/camptocamp/puppet-systemd'
-      ref: '2.12.0'
+    systemd:          'https://github.com/camptocamp/puppet-systemd'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,29 +2,20 @@
 # @api private
 class pulpcore::service {
   include apache
+  $socket_service_ensure = bool2str($pulpcore::service_ensure, 'running', 'stopped')
 
-  systemd::unit_file { 'pulpcore-api.socket':
-    content => template('pulpcore/pulpcore-api.socket.erb'),
-    active  => $pulpcore::service_ensure,
-    enable  => $pulpcore::service_enable,
+  pulpcore::socket_service { 'pulpcore-api':
+    ensure          => $socket_service_ensure,
+    enable          => $pulpcore::service_enable,
+    socket_content  => template('pulpcore/pulpcore-api.socket.erb'),
+    service_content => template('pulpcore/pulpcore-api.service.erb'),
   }
 
-  systemd::unit_file { 'pulpcore-api.service':
-    content => template('pulpcore/pulpcore-api.service.erb'),
-    active  => $pulpcore::service_ensure,
-    enable  => $pulpcore::service_enable,
-  }
-
-  systemd::unit_file { 'pulpcore-content.socket':
-    content => template('pulpcore/pulpcore-content.socket.erb'),
-    active  => $pulpcore::service_ensure,
-    enable  => $pulpcore::service_enable,
-  }
-
-  systemd::unit_file { 'pulpcore-content.service':
-    content => template('pulpcore/pulpcore-content.service.erb'),
-    active  => $pulpcore::service_ensure,
-    enable  => $pulpcore::service_enable,
+  pulpcore::socket_service { 'pulpcore-content':
+    ensure          => $socket_service_ensure,
+    enable          => $pulpcore::service_enable,
+    socket_content  => template('pulpcore/pulpcore-content.socket.erb'),
+    service_content => template('pulpcore/pulpcore-content.service.erb'),
   }
 
   systemd::unit_file { 'pulpcore-resource-manager.service':

--- a/manifests/socket_service.pp
+++ b/manifests/socket_service.pp
@@ -1,0 +1,61 @@
+# @summary Create a systemd socket activated service
+# @api private
+#
+# Systemd socket activated services have their own dependencies. This is a
+# convenience wrapper around systemd::unit_file.
+#
+# @param name [Pattern['^[^/]+$']]
+#   The target unit file to create
+# @param socket_content
+#   The content for the socket unit file. Required if ensure isn't absent.
+# @param service_content
+#   The content for the service unit file. Required if ensure isn't absent.
+# @param enable
+#   Whether to enable or disable the service. By default this is derived from
+#   $ensure but can be overridden for advanced use cases where the service is
+#   running during a migration but shouldn't be enabled on boot.
+define pulpcore::socket_service (
+  Enum['running', 'stopped', 'present', 'absent'] $ensure = 'running',
+  Optional[String[1]] $socket_content = undef,
+  Optional[String[1]] $service_content = undef,
+  Optional[Boolean] $enable = undef,
+) {
+  assert_type(Pattern['^[^/]+$'], $name)
+
+  if $ensure != 'absent' {
+    assert_type(NotUndef, $socket_content)
+    assert_type(NotUndef, $service_content)
+  }
+
+  $active = $ensure ? {
+    'running' => true,
+    'stopped' => false,
+    'absent'  => false,
+    default   => undef,
+  }
+  $real_enable = pick($enable, $active)
+
+  $unit_file_ensure = bool2str($ensure == 'absent', 'absent', 'present')
+
+  systemd::unit_file { "${name}.socket":
+    ensure  => $unit_file_ensure,
+    content => $socket_content,
+    active  => $active,
+    enable  => $real_enable,
+  }
+
+  systemd::unit_file { "${name}.service":
+    ensure  => $unit_file_ensure,
+    content => $service_content,
+    active  => $active,
+    enable  => $real_enable,
+  }
+
+  if $active or $real_enable {
+    # Systemd needs both .socket and .service to be loaded when starting the
+    # service. The unit_file takes care of matching, this ensures the
+    # non-matching order.
+    File["/etc/systemd/system/${name}.socket"] -> Service["${name}.service"]
+    File["/etc/systemd/system/${name}.service"] -> Service["${name}.socket"]
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppet/extlib",

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -119,6 +119,14 @@ describe 'pulpcore' do
 
         it 'configures services' do
           is_expected.to contain_class('pulpcore::service')
+          is_expected.to contain_pulpcore__socket_service('pulpcore-api')
+          is_expected.to contain_systemd__unit_file('pulpcore-api.socket')
+          is_expected.to contain_systemd__unit_file('pulpcore-api.service')
+          is_expected.to contain_file('/etc/systemd/system/pulpcore-api.socket').that_comes_before('Service[pulpcore-api.service]')
+          is_expected.to contain_pulpcore__socket_service('pulpcore-content')
+          is_expected.to contain_systemd__unit_file('pulpcore-content.socket')
+          is_expected.to contain_systemd__unit_file('pulpcore-content.service')
+          is_expected.to contain_file('/etc/systemd/system/pulpcore-content.socket').that_comes_before('Service[pulpcore-content.service]')
           is_expected.to contain_systemd__unit_file('pulpcore-resource-manager.service')
           is_expected.to contain_systemd__unit_file('pulpcore-worker@.service')
           is_expected.to contain_service("pulpcore-worker@1.service").with_ensure(true)


### PR DESCRIPTION
After [Puppet 5 is dropped](https://github.com/theforeman/puppet-pulpcore/pull/197) camptocamp/systemd 2.x support can be dropped. However, for now I've chosen to support both since I'm not entirely sure if all dependencies in the installer allow 3.x just yet.