### PR TITLE
Fixes #32766 - adds scheme and pulp content path to setting value

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -20,14 +20,6 @@ class pulpcore::apache (
   $content_base_url = "unix://${pulpcore::content_socket_path}|http://pulpcore-content"
   $content_url = "${content_base_url}${content_path}"
 
-  if ! $pulpcore::apache_https_vhost {
-    fail('HTTPS must be turned on for Ansible content')
-  } elsif $pulpcore::apache::https_port != 443 {
-    $external_content_url = "https://${pulpcore::servername}:${pulpcore::apache::https_port}${pulpcore::apache::content_path}"
-  } else {
-    $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
-  }
-
   $docroot_directory = {
     'provider'       => 'Directory',
     'path'           => $pulpcore::apache_docroot,
@@ -173,5 +165,13 @@ class pulpcore::apache (
           persistent => true,
       })
     }
+  }
+
+  if ! $pulpcore::apache_https_vhost {
+    fail('HTTPS must be turned on for Ansible content')
+  } elsif $https_port != 443 {
+    $external_content_url = "https://${pulpcore::servername}:${https_port}${content_path}"
+  } else {
+    $external_content_url = "https://${pulpcore::servername}${content_path}"
   }
 }

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -27,7 +27,7 @@ class pulpcore::apache (
   } else {
     $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
   }
-  
+
   $docroot_directory = {
     'provider'       => 'Directory',
     'path'           => $pulpcore::apache_docroot,

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -20,6 +20,14 @@ class pulpcore::apache (
   $content_base_url = "unix://${pulpcore::content_socket_path}|http://pulpcore-content"
   $content_url = "${content_base_url}${content_path}"
 
+  if ! $pulpcore::apache_https_vhost {
+    fail('HTTPS must be turned on for Ansible content')
+  } elsif $pulpcore::apache::https_port != 443 {
+    $external_content_url = "https://${pulpcore::servername}:${pulpcore::apache::https_port}${pulpcore::apache::content_path}"
+  } else {
+    $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
+  }
+  
   $docroot_directory = {
     'provider'       => 'Directory',
     'path'           => $pulpcore::apache_docroot,

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -166,12 +166,4 @@ class pulpcore::apache (
       })
     }
   }
-
-  if ! $pulpcore::apache_https_vhost {
-    fail('HTTPS must be turned on for Ansible content')
-  } elsif $https_port != 443 {
-    $external_content_url = "https://${pulpcore::servername}:${https_port}${content_path}"
-  } else {
-    $external_content_url = "https://${pulpcore::servername}${content_path}"
-  }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -16,7 +16,7 @@ class pulpcore::plugin::ansible(
   }
 
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${pulpcore::apache::external_content_url}\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${pulpcore::apache::external_content_url}/\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -16,7 +16,7 @@ class pulpcore::plugin::ansible(
   }
 
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${pulpcore::servername}\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"https://${pulpcore::servername}/pulp/content/\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -24,7 +24,7 @@ class pulpcore::plugin::ansible(
   }
 
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}/\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -15,8 +15,16 @@ class pulpcore::plugin::ansible(
     ],
   }
 
+  if ! $pulpcore::apache_https_vhost {
+    fail('HTTPS must be turned on for Ansible content')
+  } elsif $pulpcore::apache::https_port != 443 {
+    $external_content_url = "https://${pulpcore::servername}:${pulpcore::apache::https_port}${pulpcore::apache::content_path}"
+  } else {
+    $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
+  }
+
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${pulpcore::apache::external_content_url}/\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}/\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -15,8 +15,16 @@ class pulpcore::plugin::ansible(
     ],
   }
 
+  if ! $pulpcore::apache_https_vhost {
+    fail('HTTPS must be turned on for Ansible content')
+  } elsif $pulpcore::apache::https_port != 443 {
+    $external_content_url = "https://${pulpcore::servername}:${pulpcore::apache::https_port}${pulpcore::apache::content_path}"
+  } else {
+    $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
+  }
+
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"https://${pulpcore::servername}/pulp/content/\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -15,16 +15,8 @@ class pulpcore::plugin::ansible(
     ],
   }
 
-  if ! $pulpcore::apache_https_vhost {
-    fail('HTTPS must be turned on for Ansible content')
-  } elsif $pulpcore::apache::https_port != 443 {
-    $external_content_url = "https://${pulpcore::servername}:${pulpcore::apache::https_port}${pulpcore::apache::content_path}"
-  } else {
-    $external_content_url = "https://${pulpcore::servername}${pulpcore::apache::content_path}"
-  }
-
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${pulpcore::servername}\"\nANSIBLE_CONTENT_HOSTNAME = \"${pulpcore::apache::external_content_url}\"",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }

--- a/spec/classes/plugin_ansible_spec.rb
+++ b/spec/classes/plugin_ansible_spec.rb
@@ -25,7 +25,7 @@ CONTENT
                            .with_content(expected_vhost_content)
         is_expected.to contain_concat__fragment('plugin-ansible')
           .with_content(/^ANSIBLE_API_HOSTNAME = "foo.example.com"/)
-          .with_content(/^ANSIBLE_CONTENT_HOSTNAME = "https:\/\/foo.example.com\/pulp\/content\/"/)
+          .with_content(%r{^ANSIBLE_CONTENT_HOSTNAME = "https://foo.example.com/pulp/content/"})
       end
     end
   end

--- a/spec/classes/plugin_ansible_spec.rb
+++ b/spec/classes/plugin_ansible_spec.rb
@@ -25,7 +25,7 @@ CONTENT
                            .with_content(expected_vhost_content)
         is_expected.to contain_concat__fragment('plugin-ansible')
           .with_content(/^ANSIBLE_API_HOSTNAME = "foo.example.com"/)
-          .with_content(/^ANSIBLE_CONTENT_HOSTNAME = "foo.example.com"/)
+          .with_content(/^ANSIBLE_CONTENT_HOSTNAME = "https:\/\/foo.example.com\/pulp\/content\/"/)
       end
     end
   end

--- a/spec/classes/plugin_ansible_spec.rb
+++ b/spec/classes/plugin_ansible_spec.rb
@@ -25,7 +25,7 @@ CONTENT
                            .with_content(expected_vhost_content)
         is_expected.to contain_concat__fragment('plugin-ansible')
           .with_content(/^ANSIBLE_API_HOSTNAME = "foo.example.com"/)
-          .with_content(%r{^ANSIBLE_CONTENT_HOSTNAME = "https://foo.example.com/pulp/content/"})
+          .with_content(%r{^ANSIBLE_CONTENT_HOSTNAME = "https://foo.example.com/pulp/content"})
       end
     end
   end


### PR DESCRIPTION
The current value omits the scheme and pulp content path, which causes issues when syncing content across capsules (and probably will cause other failures too).