### PR TITLE
Support Pulp 3.13, drop earlier versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
         setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
         puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         pulpcore_version:
-          - '3.9'
-          - '3.11'
+          - '3.13'
     name: Acceptance / ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.11
+### Pulpcore 3.13
 
-Recommended version.
-
-### Pulpcore 3.9
-
-At least version 3.9.1 should be used.
+Only supported version.
 
 ## Installation layout
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.11',
+  Pattern['^\d+\.\d+$'] $version = '3.13',
 ) {
   $context = {
     'version'   => $version,

--- a/templates/pulpcore-resource-manager.service.erb
+++ b/templates/pulpcore-resource-manager.service.erb
@@ -11,11 +11,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-resource-manager
-ExecStart=/usr/libexec/pulpcore/rq worker \
-          -w pulpcore.tasking.worker.PulpWorker -n resource-manager \
-          -c 'pulpcore.rqconfig' \
-          --disable-job-desc-logging
-
+ExecStart=/usr/libexec/pulpcore/pulpcore-worker --resource-manager
 SyslogIdentifier=pulpcore-resource-manager
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either

--- a/templates/pulpcore-worker@.service.erb
+++ b/templates/pulpcore-worker@.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pulp RQ Worker
+Description=Pulp Worker
 After=network-online.target
 Wants=network-online.target
 
@@ -13,11 +13,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-worker-%i
-ExecStart=/usr/libexec/pulpcore/rq worker \
-          -w pulpcore.tasking.worker.PulpWorker \
-          -c 'pulpcore.rqconfig' \
-          --disable-job-desc-logging
-
+ExecStart=/usr/libexec/pulpcore/pulpcore-worker
 SyslogIdentifier=pulpcore-worker-%i
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either


### PR DESCRIPTION
Pulp 3.13 moves to a new wrapper for the worker. This isn't present in older releases so support for them is dropped.