### PR TITLE
Refs #32910: Add ability to enable content caching

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,12 @@
 # @param api_client_auth_cn_map
 #   Mapping of certificate common name and Pulp user to authenticate to Pulp API.
 #
+# @param cache_enabled
+#   Enables Redis based content caching within the Pulp content app.
+#
+# @param cache_expires_ttl
+#   The number of seconds that content should be cached for. Specify 'None' to never expire the cache.
+#
 # @example Default configuration
 #   include pulpcore
 #
@@ -204,6 +210,8 @@ class pulpcore (
   Integer[0] $content_service_worker_timeout = 90,
   Integer[0] $api_service_worker_timeout = 90,
   Hash[String[1], String[1]] $api_client_auth_cn_map = {},
+  Boolean $cache_enabled = false,
+  Optional[Variant[Integer[1], Enum['None']]] $cache_expires_ttl = undef,
 ) {
   $settings_file = "${config_dir}/settings.py"
 

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -23,6 +23,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
+            .with_content(%r{CACHE_ENABLED = False})
             .without_content(/sslmode/)
           is_expected.to contain_file('/etc/pulp')
           is_expected.to contain_file('/var/lib/pulp')
@@ -479,6 +480,21 @@ CONTENT
                 ],
               }
             ])
+        end
+      end
+
+      context 'can enable content caching and set an expires' do
+        let :params do
+          {
+            cache_enabled: true,
+            cache_expires_ttl: 60,
+          }
+        end
+
+        it do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{CACHE_ENABLED = True})
+            .with_content(%r{CACHE_SETTINGS = \{\n    'EXPIRES_TTL': 60,\n\}})
         end
       end
     end

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -43,3 +43,10 @@ ALLOWED_CONTENT_CHECKSUMS = <%= scope['pulpcore::allowed_content_checksums'] %>
 
 # Derive HTTP/HTTPS via the X-Forwarded-Proto header set by Apache
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+CACHE_ENABLED = <%= scope['pulpcore::cache_enabled'] ? 'True' : 'False' %>
+<% if scope['pulpcore::cache_enabled'] && scope['pulpcore::cache_expires_ttl'] -%>
+CACHE_SETTINGS = {
+    'EXPIRES_TTL': <%= scope['pulpcore::cache_expires_ttl'] %>,
+}
+<% end -%>


### PR DESCRIPTION
Adds a flag to enable content caching via Redis. This is disabled
by default as its a new optional feature in Pulp 3.14.

Requires https://github.com/pulp/pulpcore/pull/1356 being present which is targeted for Pulpcore 3.14. This also updates the README to reflect that minimum version.