### PR TITLE
#32917 - Deploy Redis only when required by enabled features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.13
+### Pulpcore 3.14
 
 Only supported version.
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,6 +27,8 @@ class pulpcore::database(
     require     => Pulpcore::Admin['migrate --noinput'],
   }
 
-  include redis
+  if $pulpcore::deploy_redis {
+    include redis
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,7 +208,7 @@ class pulpcore (
   Pulpcore::ChecksumTypes $allowed_content_checksums = ['sha224', 'sha256', 'sha384', 'sha512'],
   String[1] $remote_user_environ_name = 'HTTP_REMOTE_USER',
   Integer[0] $worker_count = min(8, $facts['processors']['count']),
-  Boolean $use_rq_tasking_system = true,
+  Boolean $use_rq_tasking_system = false,
   Boolean $service_enable = true,
   Boolean $service_ensure = true,
   Integer[0] $content_service_worker_count = (2*min(8, $facts['processors']['count']) + 1),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,6 +160,12 @@
 # @param api_client_auth_cn_map
 #   Mapping of certificate common name and Pulp user to authenticate to Pulp API.
 #
+# @param pulp_cache_enable
+#   Enables Redis based content caching within the Pulp content app.
+#
+# @param pulp_cache_expires_ttl
+#   The number of seconds that content should be cached for.
+#
 # @example Default configuration
 #   include pulpcore
 #
@@ -210,6 +216,8 @@ class pulpcore (
   Integer[0] $content_service_worker_timeout = 90,
   Integer[0] $api_service_worker_timeout = 90,
   Hash[String[1], String[1]] $api_client_auth_cn_map = {},
+  Boolean $pulp_cache_enable = false,
+  Integer[0] $pulp_cache_expires_ttl = 60,
 ) {
   $settings_file = "${config_dir}/settings.py"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,6 +132,11 @@
 #   available, likely results in performance degradation due to I/O blocking and is not recommended in most cases. Modifying this parameter should
 #   be done incrementally with benchmarking at each step to determine an optimal value for your deployment.
 #
+# @param use_rq_tasking_system
+#   Use the older RQ workers tasking system instead of the newer PostgreSQL tasking system introduced in Pulpcore 3.13.
+#   Any benchmarking you did to optimize worker_count or other tasking related parameters will no longer be accurate after changing the tasking system.
+#   Do not modify this setting unless you understand the implications for performance and stability.
+#
 # @param service_enable
 #   Enable/disable Pulp services at boot.
 #
@@ -197,6 +202,7 @@ class pulpcore (
   Pulpcore::ChecksumTypes $allowed_content_checksums = ['sha224', 'sha256', 'sha384', 'sha512'],
   String[1] $remote_user_environ_name = 'HTTP_REMOTE_USER',
   Integer[0] $worker_count = min(8, $facts['processors']['count']),
+  Boolean $use_rq_tasking_system = true,
   Boolean $service_enable = true,
   Boolean $service_ensure = true,
   Integer[0] $content_service_worker_count = (2*min(8, $facts['processors']['count']) + 1),

--- a/spec/acceptance/disable_new_tasking_system_spec.rb
+++ b/spec/acceptance/disable_new_tasking_system_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper_acceptance'
+
+describe 'initial configuration with newer postgresql tasking system' do
+  certdir = '/etc/pulpcore-certs'
+
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      class { 'pulpcore':
+        worker_count          => 1,
+        use_rq_tasking_system => false,
+      }
+      PUPPET
+    end
+  end
+
+  describe service('httpd') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-api') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-content') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-resource-manager') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-worker@1') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/status/", cacert: "#{certdir}/ca-cert.pem") do
+    its(:response_code) { is_expected.to eq(200) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("PULP_SETTINGS=/etc/pulp/settings.py pulpcore-manager diffsettings") do
+    its(:stdout) { is_expected.to match(/^USE_NEW_WORKER_TYPE = True/) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/^0 workers, /) }
+    its(:stdout) { is_expected.not_to match(/^resource-manager /) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end
+
+describe 'reconfigure pulpcore to use older rq worker tasking system' do
+  certdir = '/etc/pulpcore-certs'
+
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      class { 'pulpcore':
+        worker_count          => 1,
+        use_rq_tasking_system => true,
+      }
+      PUPPET
+    end
+  end
+
+  describe service('httpd') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-api') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-content') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-resource-manager') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-worker@1') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/status/", cacert: "#{certdir}/ca-cert.pem") do
+    its(:response_code) { is_expected.to eq(200) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("PULP_SETTINGS=/etc/pulp/settings.py pulpcore-manager diffsettings") do
+    its(:stdout) { is_expected.to match(/^USE_NEW_WORKER_TYPE = False/) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/^2 workers, /) }
+    its(:stdout) { is_expected.to match(/^resource-manager /) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end

--- a/spec/acceptance/enable_new_tasking_system_spec.rb
+++ b/spec/acceptance/enable_new_tasking_system_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper_acceptance'
+
+describe 'initial configuration with older rq worker tasking system' do
+  certdir = '/etc/pulpcore-certs'
+
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      class { 'pulpcore':
+        worker_count          => 1,
+        use_rq_tasking_system => true,
+      }
+      PUPPET
+    end
+  end
+
+  describe service('httpd') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-api') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-content') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-resource-manager') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-worker@1') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/status/", cacert: "#{certdir}/ca-cert.pem") do
+    its(:response_code) { is_expected.to eq(200) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("PULP_SETTINGS=/etc/pulp/settings.py pulpcore-manager diffsettings") do
+    its(:stdout) { is_expected.to match(/^USE_NEW_WORKER_TYPE = False/) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/^2 workers, /) }
+    its(:stdout) { is_expected.to match(/^resource-manager /) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end
+
+describe 'reconfigure pulpcore to use newer postgresql tasking system' do
+  certdir = '/etc/pulpcore-certs'
+
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-PUPPET
+      class { 'pulpcore':
+        worker_count          => 1,
+        use_rq_tasking_system => false,
+      }
+      PUPPET
+    end
+  end
+
+  describe service('httpd') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-api') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-content') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-resource-manager') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('pulpcore-worker@1') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/status/", cacert: "#{certdir}/ca-cert.pem") do
+    its(:response_code) { is_expected.to eq(200) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("PULP_SETTINGS=/etc/pulp/settings.py pulpcore-manager diffsettings") do
+    its(:stdout) { is_expected.to match(/^USE_NEW_WORKER_TYPE = True/) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/^0 workers, /) }
+    its(:stdout) { is_expected.not_to match(/^resource-manager /) }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -23,6 +23,8 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
+            .with_content(%r{PULP_CACHE_ENABLED = False})
+            .with_content(%r{PULP_CACHE_SETTINGS = \{\n    'EXPIRES_TTL': 60,\n\}})
             .without_content(/sslmode/)
           is_expected.to contain_file('/etc/pulp')
           is_expected.to contain_file('/var/lib/pulp')

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+
+describe 'pulpcore' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { override_facts(os_facts, os: {selinux: {enabled: true}}) }
+
+      context 'manage_redis false' do
+        let(:params) do
+          { manage_redis: false }
+        end
+
+        context 'use_rq_tasking_system false' do
+          let(:params) do
+            super().merge({ use_rq_tasking_system: false })
+          end
+
+          context 'pulp_cache_enable false' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: false })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'does not configure redis' do
+              is_expected.not_to contain_class('redis')
+            end
+
+            it 'does not configure pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .without_content(/REDIS_HOST/)
+                .without_content(/REDIS_PORT/)
+                .without_content(/REDIS_DB/)
+            end
+          end
+
+          context 'pulp_cache_enable true' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: true })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'does not configure redis' do
+              is_expected.not_to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+        end
+
+        context 'use_rq_tasking_system true' do
+          let(:params) do
+            super().merge({ use_rq_tasking_system: true })
+          end
+
+          context 'pulp_cache_enable false' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: false })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'does not configure redis' do
+              is_expected.not_to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+
+          context 'pulp_cache_enable true' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: true })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'does not configure redis' do
+              is_expected.not_to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+        end
+      end
+
+      context 'manage_redis true' do
+        let(:params) do
+          { manage_redis: true }
+        end
+
+        context 'use_rq_tasking_system false' do
+          let(:params) do
+            super().merge({ use_rq_tasking_system: false })
+          end
+
+          context 'pulp_cache_enable false' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: false })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'does not configure redis' do
+              is_expected.not_to contain_class('redis')
+            end
+
+            it 'does not configure pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .without_content(/REDIS_HOST/)
+                .without_content(/REDIS_PORT/)
+                .without_content(/REDIS_DB/)
+            end
+          end
+
+          context 'pulp_cache_enable true' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: true })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'configures redis' do
+              is_expected.to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+        end
+
+        context 'use_rq_tasking_system true' do
+          let(:params) do
+            super().merge({ use_rq_tasking_system: true })
+          end
+
+          context 'pulp_cache_enable false' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: false })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'configures redis' do
+              is_expected.to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+
+          context 'pulp_cache_enable true' do
+            let(:params) do
+              super().merge({ pulp_cache_enable: true })
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'configures redis' do
+              is_expected.to contain_class('redis')
+            end
+
+            it 'configures pulpcore connection to redis' do
+              is_expected.to contain_concat__fragment('base')
+                .with_content(/REDIS_HOST/)
+                .with_content(/REDIS_PORT/)
+                .with_content(/REDIS_DB/)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -45,3 +45,8 @@ ALLOWED_CONTENT_CHECKSUMS = <%= scope['pulpcore::allowed_content_checksums'] %>
 
 # Derive HTTP/HTTPS via the X-Forwarded-Proto header set by Apache
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+PULP_CACHE_ENABLED = <%= scope['pulpcore::pulp_cache_enable'] ? 'True' : 'False' %>
+PULP_CACHE_SETTINGS = {
+    'EXPIRES_TTL': <%= scope['pulpcore::pulp_cache_expires_ttl'] %>,
+}

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -23,6 +23,8 @@ REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>
 
+USE_NEW_WORKER_TYPE=<%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
+
 MEDIA_ROOT = "<%= scope['pulpcore::media_root'] %>"
 STATIC_ROOT = "<%= scope['pulpcore::static_root'] %>"
 STATIC_URL = "<%= scope['pulpcore::static_url'] %>"

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,9 +19,12 @@ DATABASES = {
 <% end -%>
     },
 }
+
+<% if scope['pulpcore::configure_redis_connection'] -%>
 REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>
+<% end -%>
 
 USE_NEW_WORKER_TYPE=<%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
 


### PR DESCRIPTION
    Redis is now only required by this module when using at least
    one of the `use_rq_tasking_system` or `pulp_cache_enable` features.
    This commit introduces a new parameter `manage_redis`, default to true,
    which should be used when this module is responsible for managing Redis
    deployment. When false, this module will never attempt to deploy Redis,
    although it will still configure Pulpcore's connection to Redis if
    required by one or more enabled features.

Requires: https://github.com/theforeman/puppet-pulpcore/pull/203
Requires: https://github.com/theforeman/puppet-pulpcore/pull/204