### PR TITLE
Refs #32917 - Don't deploy or configure Redis with new tasking system

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,6 +27,8 @@ class pulpcore::database(
     require     => Pulpcore::Admin['migrate --noinput'],
   }
 
-  include redis
+  if $pulpcore::uses_redis {
+    include redis
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,6 +221,8 @@ class pulpcore (
 ) {
   $settings_file = "${config_dir}/settings.py"
 
+  $uses_redis = $use_rq_tasking_system or $cache_enabled
+
   contain pulpcore::install
   contain pulpcore::database
   contain pulpcore::config

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -79,10 +79,19 @@ describe 'basic installation' do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
+  describe service('rh-redis5-redis'), if: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
+    it { is_expected.not_to be_running }
+    it { is_expected.not_to be_enabled }
+  end
+
+  describe service('redis'), unless: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
+    it { is_expected.not_to be_running }
+    it { is_expected.not_to be_enabled }
+  end
+
   describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
-    its(:stdout) { is_expected.to match(/^0 workers, /) }
-    its(:stdout) { is_expected.not_to match(/^resource-manager /) }
-    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.not_to match(/Connection refused/) }
+    its(:exit_status) { is_expected.to eq 1 }
   end
 end
 
@@ -172,6 +181,12 @@ describe 'with content cache enabled' do
   describe service('redis'), unless: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/^0 workers, /) }
+    its(:stdout) { is_expected.not_to match(/^resource-manager /) }
+    its(:exit_status) { is_expected.to eq 0 }
   end
 
   describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/status/", cacert: "#{certdir}/ca-cert.pem") do

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -23,8 +23,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_EXPORT_PATHS = \[\]})
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
-            .with_content(%r{CACHE_ENABLED = False})
-            .without_content(/sslmode/)
+            .without_content(%r{sslmode})
           is_expected.to contain_file('/etc/pulp')
           is_expected.to contain_file('/var/lib/pulp')
           is_expected.to contain_file('/var/lib/pulp/sync_imports')
@@ -41,7 +40,7 @@ describe 'pulpcore' do
           is_expected.to contain_exec('pulpcore-manager collectstatic --noinput')
         end
 
-        it 'configures the database' do
+        it 'configures the PostgreSQL database' do
           is_expected.to contain_class('pulpcore::database')
           is_expected.to contain_class('postgresql::server')
           is_expected.to contain_postgresql__server__db('pulpcore')
@@ -49,6 +48,30 @@ describe 'pulpcore' do
           is_expected.to contain_exec('pulpcore-manager migrate --noinput')
           is_expected.to contain_pulpcore__admin('reset-admin-password --random')
           is_expected.to contain_exec('pulpcore-manager reset-admin-password --random')
+        end
+
+        it 'does not install Redis' do
+          is_expected.not_to contain_class('redis')
+        end
+
+        it 'does not configure Pulpcore connection to Redis' do
+          is_expected.to contain_concat__fragment('base')
+            .without_content(%r{REDIS_HOST})
+            .without_content(%r{REDIS_POST})
+            .without_content(%r{REDIS_DB})
+        end
+
+        it 'does not configure content caching' do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(/CACHE_ENABLED = False/)
+            .without_content(%r{CACHE_SETTINGS})
+            .without_content(%r{'EXPIRES_TTL':})
+        end
+
+        it 'configures pulpcore to use PostgreSQL tasking system' do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{USE_NEW_WORKER_TYPE = True})
+          is_expected.to contain_systemd__unit_file('pulpcore-resource-manager.service').with_ensure('absent')
         end
 
         it 'configures apache' do
@@ -128,7 +151,6 @@ describe 'pulpcore' do
           is_expected.to contain_systemd__unit_file('pulpcore-content.socket')
           is_expected.to contain_systemd__unit_file('pulpcore-content.service')
           is_expected.to contain_file('/etc/systemd/system/pulpcore-content.socket').that_comes_before('Service[pulpcore-content.service]')
-          is_expected.to contain_systemd__unit_file('pulpcore-resource-manager.service').with_ensure('absent')
           is_expected.to contain_systemd__unit_file('pulpcore-worker@.service')
           is_expected.to contain_service("pulpcore-worker@1.service").with_ensure(true)
           is_expected.not_to contain_service("pulpcore-worker@2.service")
@@ -491,10 +513,45 @@ CONTENT
           }
         end
 
-        it do
+        it 'configures content caching' do
           is_expected.to contain_concat__fragment('base')
             .with_content(%r{CACHE_ENABLED = True})
             .with_content(%r{CACHE_SETTINGS = \{\n    'EXPIRES_TTL': 60,\n\}})
+        end
+
+        it 'installs Redis' do
+          is_expected.to contain_class('redis')
+        end
+
+        it 'configures Pulpcore connection to Redis' do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{REDIS_HOST})
+            .with_content(%r{REDIS_PORT})
+            .with_content(%r{REDIS_DB})
+        end
+      end
+
+      context 'can enable RQ tasking system' do
+        let :params do
+          {
+            use_rq_tasking_system: true,
+          }
+        end
+
+        it 'configures RQ tasking system' do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{USE_NEW_WORKER_TYPE = False})
+        end
+
+        it 'installs Redis' do
+          is_expected.to contain_class('redis')
+        end
+
+        it 'configures Pulpcore connection to Redis' do
+          is_expected.to contain_concat__fragment('base')
+            .with_content(%r{REDIS_HOST})
+            .with_content(%r{REDIS_PORT})
+            .with_content(%r{REDIS_DB})
         end
       end
     end

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,10 +19,13 @@ DATABASES = {
 <% end -%>
     },
 }
+
+<% if scope['pulpcore::uses_redis'] -%>
 REDIS_HOST = "localhost"
 REDIS_PORT = "<%= scope['redis::port'] %>"
 REDIS_DB = <%= scope['pulpcore::redis_db'] %>
 
+<% end -%>
 USE_NEW_WORKER_TYPE = <%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
 
 MEDIA_ROOT = "<%= scope['pulpcore::media_root'] %>"


### PR DESCRIPTION
This is a more gradual alternative to https://github.com/theforeman/puppet-pulpcore/pull/206

In particular, it doesn't include the ability to enable or disable management of Redis, nor does it consider the content caching feature.

it simply includes the redis class and configures Pulpcore for Redis, based on the value of `use_rq_tasking_system`