### PR TITLE
Refactor pulpcore worker_count tests and add additional tests

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -6,9 +6,7 @@ describe 'basic installation' do
   it_behaves_like 'an idempotent resource' do
     let(:manifest) do
       <<-PUPPET
-      class { 'pulpcore':
-        worker_count => 2,
-      }
+      include pulpcore
       PUPPET
     end
   end
@@ -36,11 +34,6 @@ describe 'basic installation' do
   describe service('pulpcore-worker@1') do
     it { is_expected.to be_enabled }
     it { is_expected.to be_running }
-  end
-
-  describe service('pulpcore-worker@3') do
-    it { is_expected.not_to be_enabled }
-    it { is_expected.not_to be_running }
   end
 
   describe port(80) do
@@ -84,49 +77,6 @@ describe 'basic installation' do
     its(:stdout) { is_expected.not_to match(/^resource-manager /) }
     its(:exit_status) { is_expected.to eq 0 }
   end
-end
-
-describe 'reducing worker count' do
-  it_behaves_like 'an idempotent resource' do
-    let(:manifest) do
-      <<-PUPPET
-      class { 'pulpcore':
-        worker_count => 1,
-      }
-      PUPPET
-    end
-  end
-
-  describe service('httpd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('pulpcore-api') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('pulpcore-content') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('pulpcore-resource-manager') do
-    it { is_expected.not_to be_enabled }
-    it { is_expected.not_to be_running }
-  end
-
-  describe service('pulpcore-worker@1') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('pulpcore-worker@2') do
-    it { is_expected.not_to be_enabled }
-    it { is_expected.not_to be_running }
-  end
-
 end
 
 describe 'with content cache enabled' do

--- a/spec/acceptance/worker_count_spec.rb
+++ b/spec/acceptance/worker_count_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper_acceptance'
+
+describe 'configures pulpcore worker count', :order => :defined do
+  context 'initial configuration with 2 pulpcore workers' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'pulpcore':
+          worker_count => 2,
+        }
+        PUPPET
+      end
+    end
+
+    [1,2].each do |i|
+      describe service("pulpcore-worker@#{i}") do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+    end
+
+    describe service('pulpcore-worker@3') do
+      it { is_expected.not_to be_enabled }
+      it { is_expected.not_to be_running }
+    end
+  end
+
+  context 'reconfigure to use 1 pulpcore worker' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'pulpcore':
+          worker_count => 1,
+        }
+        PUPPET
+      end
+    end
+
+    describe service('pulpcore-worker@1') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    [2,3].each do |i|
+      describe service("pulpcore-worker@#{i}") do
+        it { is_expected.not_to be_enabled }
+        it { is_expected.not_to be_running }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit splits the acceptance tests for worker count changes out
into a separate file, spec/acceptance/worker_count.rb. It also adds
new cases to spec tests to ensure proper interaction of configured
worker_count, previously configured worker_count, and cpu count.