### PR TITLE
acceptance: rq info should return connection refused when redis is no…

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -79,10 +79,19 @@ describe 'basic installation' do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
-  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
-    its(:stdout) { is_expected.to match(/^0 workers, /) }
-    its(:stdout) { is_expected.not_to match(/^resource-manager /) }
-    its(:exit_status) { is_expected.to eq 0 }
+  describe service('rh-redis5-redis'), if: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
+    it { is_expected.not_to be_running }
+    it { is_expected.not_to be_enabled }
+  end
+
+  describe service('redis'), unless: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
+    it { is_expected.not_to be_running }
+    it { is_expected.not_to be_enabled }
+  end
+
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    its(:stdout) { is_expected.to match(/Connection refused/) }
+    its(:exit_status) { is_expected.to eq 1 }
   end
 end
 


### PR DESCRIPTION
…t installed

The test was enforcing incorrect behavior. This commit fixes the typo