### PR TITLE
Fixes #32968 - Add logging configuration to settings.py

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -55,3 +55,13 @@ CACHE_SETTINGS = {
     'EXPIRES_TTL': <%= scope['pulpcore::cache_expires_ttl'] %>,
 }
 <% end -%>
+
+LOGGING = {
+    "dynaconf_merge": True,
+    "loggers": {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        }
+    }
+}


### PR DESCRIPTION
Lightweight alternative to https://github.com/theforeman/puppet-pulpcore/pull/212

Adds the configuration for logging at level `INFO` in such a way that it's easy for the user or another tool to reconfigure to another level such as `DEBUG` (I tested this by installing, then replacing `INFO` with `DEBUG`, restarting services, and observing `DEBUG` level messages in `journalctl -u pulpcore*` output).

This does not include a parameter to configure the default log level or any tests, it is only the static configuration to provide a minimum viable version of the feature that can be iterated upon if needed.