### PR TITLE
Contain Redis within database

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,6 +27,6 @@ class pulpcore::database(
     require     => Pulpcore::Admin['migrate --noinput'],
   }
 
-  include redis
+  contain redis
 
 }

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -50,6 +50,7 @@ describe 'pulpcore' do
           is_expected.to contain_exec('pulpcore-manager migrate --noinput')
           is_expected.to contain_pulpcore__admin('reset-admin-password --random')
           is_expected.to contain_exec('pulpcore-manager reset-admin-password --random')
+          is_expected.to contain_class('redis').that_comes_before('Class[pulpcore::service]')
         end
 
         it 'configures apache' do


### PR DESCRIPTION
Without this, the Redis class may not be complete. That means Redis doesn't have to be running by the time the services are started.