### PR TITLE
Use REDIS_URL as a configuration option

### DIFF
--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -24,6 +24,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
             .with_content(%r{\s'level': 'INFO',})
+            .with_content(%r{REDIS_URL = "redis://localhost:6379/8"})
             .with_content(%r{CACHE_ENABLED = False})
             .without_content(%r{sslmode})
           is_expected.to contain_file('/etc/pulp')

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,9 +19,7 @@ DATABASES = {
 <% end -%>
     },
 }
-REDIS_HOST = "localhost"
-REDIS_PORT = "<%= scope['redis::port'] %>"
-REDIS_DB = <%= scope['pulpcore::redis_db'] %>
+REDIS_URL = "redis://localhost:<%= scope['redis::port'] %>/<%= scope['pulpcore::redis_db'] %>"
 
 USE_NEW_WORKER_TYPE = <%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
 


### PR DESCRIPTION
This is shorter in the config, but it also prepares for a connection using a different mechanism. For example, a remote Redis or using a unix socket.