### PR TITLE
Prefer the Redis unix socket if available

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,15 @@ class pulpcore::config {
     ensure_newline => true,
   }
 
+  if $redis::unixsocket != '' {
+    $redis_url = "redis+unix://${redis::unixsocket}?db=${pulpcore::redis_db}"
+  } elsif $redis::port != 0 {
+    # TODO: this assumes $redis::bind at least has localhost in it
+    $redis_url = "redis://localhost:${redis::port}/${pulpcore::redis_db}"
+  } else {
+    fail('Unable to determine Redis URL')
+  }
+
   concat::fragment { 'base':
     target  => 'pulpcore settings',
     content => template('pulpcore/settings.py.erb'),

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -24,6 +24,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
             .with_content(%r{\s'level': 'INFO',})
+            .with_content(%r{REDIS_URL = "redis://localhost:6379/8"})
             .with_content(%r{CACHE_ENABLED = False})
             .without_content(%r{sslmode})
           is_expected.to contain_file('/etc/pulp')

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -24,7 +24,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_IMPORT_PATHS = \["/var/lib/pulp/sync_imports"\]})
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
             .with_content(%r{\s'level': 'INFO',})
-            .with_content(%r{REDIS_URL = "redis://localhost:6379/8"})
+            .with_content(%r{REDIS_URL = "redis\+unix:///var/run/redis/redis\.sock\?db=8"})
             .with_content(%r{CACHE_ENABLED = False})
             .without_content(%r{sslmode})
           is_expected.to contain_file('/etc/pulp')

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,9 +19,7 @@ DATABASES = {
 <% end -%>
     },
 }
-REDIS_HOST = "localhost"
-REDIS_PORT = "<%= scope['redis::port'] %>"
-REDIS_DB = <%= scope['pulpcore::redis_db'] %>
+REDIS_URL = "redis://localhost:<%= scope['redis::port'] %>/<%= scope['pulpcore::redis_db'] %>"
 
 USE_NEW_WORKER_TYPE = <%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
 

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -19,7 +19,7 @@ DATABASES = {
 <% end -%>
     },
 }
-REDIS_URL = "redis://localhost:<%= scope['redis::port'] %>/<%= scope['pulpcore::redis_db'] %>"
+REDIS_URL = "<%= @redis_url %>"
 
 USE_NEW_WORKER_TYPE = <%= scope['pulpcore::use_rq_tasking_system'] ? "False" : "True" %>
 


### PR DESCRIPTION
Unix sockets typically have lower overhead and also allows setting stricter permissions. While iptables can be used to limit access using users, file permissions are much easier to manage.

Includes https://github.com/theforeman/puppet-pulpcore/pull/218.

Currently a draft, but I'm exploring the option of deploying a dedicated Redis instance just for Pulp (if needed). This means Redis can be tuned different. Foreman needs Redis to be in persistent mode but Pulp doesn't always:

| Tasking | Caching | Redis mode |
|---------+---------+------------+
| RQ      | Yes     | Persistent |
| RQ      | No      | Persistent |
| PG      | Yes     | Empheral   |
| PG      | No      | Off        |