### PR TITLE
Switch to puppet/systemd & allow puppet/redis 8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,4 +12,4 @@ fixtures:
       repo:           'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib'
-    systemd:          'https://github.com/camptocamp/puppet-systemd'
+    systemd:          'https://github.com/voxpupuli/puppet-systemd'

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/apache",
@@ -27,7 +27,7 @@
       "version_requirement": ">= 6.5.0 < 8.0.0"
     },
     {
-      "name": "camptocamp/systemd",
+      "name": "puppet/systemd",
       "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {


### PR DESCRIPTION
The module has been migrated and is now released under a new name.