### PR TITLE
Fixes #33445: Increase default API gunicorn worker count

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,7 +215,7 @@ class pulpcore (
   Boolean $service_enable = true,
   Boolean $service_ensure = true,
   Integer[0] $content_service_worker_count = (2*min(8, $facts['processors']['count']) + 1),
-  Integer[0] $api_service_worker_count = 1,
+  Integer[0] $api_service_worker_count = min(4, $facts['processors']['count']) + 1,
   Integer[0] $content_service_worker_timeout = 90,
   Integer[0] $api_service_worker_timeout = 90,
   Hash[String[1], String[1]] $api_client_auth_cn_map = {},

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -125,7 +125,7 @@ describe 'pulpcore' do
           is_expected.to contain_class('pulpcore::service')
           is_expected.to contain_pulpcore__socket_service('pulpcore-api')
           is_expected.to contain_systemd__unit_file('pulpcore-api.socket')
-          is_expected.to contain_systemd__unit_file('pulpcore-api.service')
+          is_expected.to contain_systemd__unit_file('pulpcore-api.service').with_content(%r{-w 2})
           is_expected.to contain_file('/etc/systemd/system/pulpcore-api.socket').that_comes_before('Service[pulpcore-api.service]')
           is_expected.to contain_pulpcore__socket_service('pulpcore-content')
           is_expected.to contain_systemd__unit_file('pulpcore-content.socket')


### PR DESCRIPTION
This increases the default API gunicorn worker count to be similar
to that of content worker count but with a smaller minimum. There
are different workloads that can require higher throughput through
the API and the current default of 1 is too low of a starting point.