### PR TITLE
Fixes #33765 - Use a system user without a login shell

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,8 +15,10 @@ class pulpcore::install {
 
   user { $pulpcore::user:
     ensure     => present,
+    system     => true,
     gid        => $pulpcore::group,
     home       => $pulpcore::user_home,
+    shell      => '/sbin/nologin',
     managehome => false,
   }
 


### PR DESCRIPTION
The user pulp doesn't need to login so it's set to /sbin/nologin.

It should also be a system user. This doesn't affect exsting installations, but it ensures fresh installations are clean. From useradd's man page:

> System users will be created with no aging information in /etc/shadow, and their numeric identifiers are chosen in the SYS_UID_MIN-SYS_UID_MAX range, defined in /etc/login.defs, instead of UID_MIN-UID_MAX (and their GID counterparts for the creation of groups).

This typically means newly created pulp users will end up with a UID < 1000 while with the current code it's > 1000.