### PR TITLE
use libexec rq wrapper to call rq in tests

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -79,7 +79,7 @@ describe 'basic installation' do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
-  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+  describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
     its(:stdout) { is_expected.to match(/^0 workers, /) }
     its(:stdout) { is_expected.not_to match(/^resource-manager /) }
     its(:exit_status) { is_expected.to eq 0 }

--- a/spec/acceptance/disable_new_tasking_system_spec.rb
+++ b/spec/acceptance/disable_new_tasking_system_spec.rb
@@ -62,7 +62,7 @@ describe 'change configuration from postgresql tasking system to rq tasking syst
       its(:exit_status) { is_expected.to eq 0 }
     end
   
-    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
       its(:stdout) { is_expected.to match(/^0 workers, /) }
       its(:stdout) { is_expected.not_to match(/^resource-manager /) }
       its(:exit_status) { is_expected.to eq 0 }
@@ -128,7 +128,7 @@ describe 'change configuration from postgresql tasking system to rq tasking syst
       its(:exit_status) { is_expected.to eq 0 }
     end
   
-    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
       its(:stdout) { is_expected.to match(/^2 workers, /) }
       its(:stdout) { is_expected.to match(/^resource-manager /) }
       its(:exit_status) { is_expected.to eq 0 }

--- a/spec/acceptance/enable_new_tasking_system_spec.rb
+++ b/spec/acceptance/enable_new_tasking_system_spec.rb
@@ -62,7 +62,7 @@ describe 'change configuration from rq tasking system to postgresql tasking syst
       its(:exit_status) { is_expected.to eq 0 }
     end
   
-    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
       its(:stdout) { is_expected.to match(/^2 workers, /) }
       its(:stdout) { is_expected.to match(/^resource-manager /) }
       its(:exit_status) { is_expected.to eq 0 }
@@ -128,7 +128,7 @@ describe 'change configuration from rq tasking system to postgresql tasking syst
       its(:exit_status) { is_expected.to eq 0 }
     end
   
-    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py rq info -c pulpcore.rqconfig") do
+    describe command("DJANGO_SETTINGS_MODULE=pulpcore.app.settings PULP_SETTINGS=/etc/pulp/settings.py /usr/libexec/pulpcore/rq info -c pulpcore.rqconfig") do
       its(:stdout) { is_expected.to match(/^0 workers, /) }
       its(:stdout) { is_expected.not_to match(/^resource-manager /) }
       its(:exit_status) { is_expected.to eq 0 }


### PR DESCRIPTION
this ensures the right SELinux context is set
and also allows to use the SCL (if there is any)