### PR TITLE
Clean up HTTPS Vhost when no longer used

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -137,6 +137,13 @@ class pulpcore::apache (
           'directories' => [$content_directory, $api_directory],
           'proxy_pass'  => [$proxy_pass_static],
       })
+
+      include apache
+      apache::vhost { 'pulpcore-https':
+        ensure   => 'absent',
+        priority => '10',
+        docroot  => $pulpcore::apache_docroot,
+      }
     }
   }
 

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -300,6 +300,9 @@ CONTENT
             )
         end
         it do
+          is_expected.to contain_apache__vhost('pulpcore-https')
+            .with_priority('10')
+            .with_ensure('absent')
           is_expected.to contain_pulpcore__apache__fragment('pulpcore')
           is_expected.to contain_apache__vhost__fragment('pulpcore-https-pulpcore')
             .with_vhost('foreman-ssl')


### PR DESCRIPTION
https://github.com/theforeman/puppet-foreman_proxy_content/pull/390 transitions to deploying the Pulpcore Vhost within puppet-FPC

This PR ensures the Vhost that was previously configured here is cleaned up on upgrades