### PR TITLE
Fixes #34298 - support KEEP_CHANGELOG_LIMIT option

### DIFF
--- a/manifests/plugin/rpm.pp
+++ b/manifests/plugin/rpm.pp
@@ -1,8 +1,14 @@
 # @summary Pulp RPM plugin
 # @param use_pulp2_content_route
 #   Whether to redirect the legacy (Pulp 2) URLs to the content server
+#
+# @param keep_changelog_limit
+#   Pulpcore's KEEP_CHANGELOG_LIMIT setting. Uses Pulpcore's default when
+#   undefined. Increasing this limit will cause pulpcore workers to use more
+#   memory when more changelogs are available in the repo metadata.
 class pulpcore::plugin::rpm (
   Boolean $use_pulp2_content_route = false,
+  Optional[Integer[0]] $keep_changelog_limit = undef,
 ) {
   if $use_pulp2_content_route {
     $context = {
@@ -28,8 +34,15 @@ class pulpcore::plugin::rpm (
     $content = undef
   }
 
+  if $keep_changelog_limit {
+    $rpm_plugin_config = "KEEP_CHANGELOG_LIMIT = ${keep_changelog_limit}"
+  } else {
+    $rpm_plugin_config = undef
+  }
+
   pulpcore::plugin { 'rpm':
     http_content  => $content,
     https_content => $content,
+    config        => $rpm_plugin_config,
   }
 }

--- a/spec/classes/plugin_rpm_spec.rb
+++ b/spec/classes/plugin_rpm_spec.rb
@@ -19,6 +19,17 @@ describe 'pulpcore::plugin::rpm' do
           is_expected.to contain_pulpcore__plugin('rpm')
             .that_subscribes_to('Class[Pulpcore::Install]')
             .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
+          is_expected.not_to contain_concat__fragment('plugin-rpm')
+        end
+
+        context 'with keep_changelog_limit' do
+          let(:params) { { keep_changelog_limit: 20 } }
+
+          it 'configures pulpcore with KEEP_CHANGELOG_LIMIT' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('plugin-rpm')
+              .with_content("\n# rpm plugin settings\nKEEP_CHANGELOG_LIMIT = 20")
+          end
         end
 
         context 'with pulp2 content route' do


### PR DESCRIPTION
This was added to Pulpcore with https://github.com/pulp/pulp_rpm/pull/2333

Backport to 3.14 is underway