### PR TITLE
Fixes #34379 - Create the Pulp group as a system group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,5 +24,6 @@ class pulpcore::install {
 
   group { $pulpcore::group:
     ensure => present,
+    system => true,
   }
 }

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -11,6 +11,16 @@ describe 'basic installation' do
     end
   end
 
+  describe user('pulp') do
+    it { is_expected.to exist }
+    its(:uid) { is_expected.to be < 1000 }
+  end
+
+  describe group('pulp') do
+    it { is_expected.to exist }
+    its(:gid) { is_expected.to be < 1000 }
+  end
+
   describe service('httpd') do
     it { is_expected.to be_enabled }
     it { is_expected.to be_running }


### PR DESCRIPTION
Similar to 5a7991ab90a25aa3add176c1714fc416053a007a but for the group instead of the user.