### PR TITLE
Make it mostly compatible with gha-puppet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
     name: Unit / Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v2
@@ -51,6 +51,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: '1'
       - name: Run tests
         run: bundle exec rake parallel_spec
 
@@ -75,6 +76,7 @@ jobs:
         with:
           ruby-version: '2.7'
           bundler-cache: true
+          cache-version: '1'
       - name: Run tests
         run: bundle exec rake beaker
         env:
@@ -84,3 +86,12 @@ jobs:
           # This locale doesn't exist in EL7 and won't be supported either.
           LANG: en_US.UTF-8
           BEAKER_FACTER_PULPCORE_VERSION: ${{ matrix.pulpcore_version }}
+
+  tests:
+    needs:
+      - unit
+      - acceptance
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+---
+# This file is different in that it also tests multiple pulpcore versions
+.github/workflows/ci.yml:
+  unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 5.5', groups: ['development', 'test']
+gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 5.5', groups: ['development', 'test']
 gem 'rake'
 
 gem 'kafo_module_lint', {"groups"=>["test"]}
@@ -15,9 +15,12 @@ gem 'puppet-lint-strict_indent-check', {"groups"=>["test"]}
 gem 'puppet-lint-undef_in_function-check', {"groups"=>["test"]}
 gem 'voxpupuli-test', '~> 1.4', {"groups"=>["test"]}
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
-gem 'puppet_metadata', '~> 0.3'
+gem 'puppet_metadata', '~> 1.3'
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
 gem 'voxpupuli-acceptance', '~> 1.0', {"groups"=>["system_tests"]}
 gem 'puppetlabs_spec_helper', {"groups"=>["system_tests"]}
+
+# Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
+gem 'rdoc', '< 6.4'
 
 # vim:ft=ruby


### PR DESCRIPTION
In this repository multiple test suites run. That is currently not supported by gha-puppet so the file becomes unmanaged. It does take the improvement of a test at the end, which allows automerge to be enabled.  It also keeps the Gemfile in sync and aligns on PUPPET_GEM_VERSION.

At the same time it increases the cache version to work around the broken Ruby 2.5 cache which includes Psych 4.