### PR TITLE
Fixes #34631 - Recurse into artifacts folder to ensure owner is proper

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,11 +30,19 @@ class pulpcore::config {
     mode   => '0775',
   }
 
-  file { [$pulpcore::cache_dir, $pulpcore::media_root]:
-    ensure => directory,
-    owner  => $pulpcore::user,
-    group  => $pulpcore::group,
-    mode   => '0750',
+  file { $pulpcore::cache_dir:
+    ensure  => directory,
+    owner   => $pulpcore::user,
+    group   => $pulpcore::group,
+    mode    => '0750',
+  }
+
+  file { $pulpcore::media_root:
+    ensure  => directory,
+    owner   => $pulpcore::user,
+    group   => $pulpcore::group,
+    mode    => '0750',
+    recurse => true,
   }
 
   file { $pulpcore::allowed_import_path:


### PR DESCRIPTION
The artifacts folder can have the wrong owner (apache) if a user's system configuration allowed for Pulp 2 to create hardlinks during the migration process.  This change tells the installer to recurse into the artifacts folder to correct the artifact file ownership. I checked with the pulp team and 750 should be just fine for artifacts.

To test:
1) On Katello 4.3+, run `chown -hR apache.pulp /var/lib/pulp/media/artifact`
2) Try to complete sync a repo. It will fail.
3) Run the installer with this change. Syncing should now work.