### PR TITLE
Add Pulpcore 3.18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
         puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         pulpcore_version:
+          - '3.18'
           - '3.17'
           - '3.16'
     name: Acceptance / ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }} - Pulp ${{ matrix.pulpcore_version }}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.17
+### Pulpcore 3.18
 
 Default recommended version.
+
+### Pulpcore 3.17
+
+Supported version.
 
 ### Pulpcore 3.16
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.17',
+  Pattern['^\d+\.\d+$'] $version = '3.18',
 ) {
   $dist_tag = "el${facts['os']['release']['major']}"
   $context = {


### PR DESCRIPTION
Looking at the last [Pulpcore version bump](https://github.com/theforeman/puppet-pulpcore/commit/6f09c2ff328fac9fcaf1388d9112a5130db3e2d7), it seems this is all we need to support Pulpcore 3.18.

3.18 is still built for EL7 so we shouldn't have to drop any of the EL7 related bits.