### PR TITLE
Add a loggers parameter and set default loggers

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,15 @@ class pulpcore::config {
     order   => '01',
   }
 
+  concat::fragment { 'logging':
+    target  => 'pulpcore settings',
+    content => epp('pulpcore/settings-logging.py.epp', {
+        'level'   => $pulpcore::log_level,
+        'loggers' => $pulpcore::loggers,
+    }),
+    order   => '02',
+  }
+
   file { $pulpcore::user_home:
     ensure => directory,
     owner  => $pulpcore::user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,11 +23,20 @@ class pulpcore::config {
     order   => '01',
   }
 
+  $loggers = {
+    'pulpcore.deprecation' => {
+      'level' => 'ERROR',
+    },
+    'django_guid'          => {
+      'level' => 'WARNING',
+    },
+  } + $pulpcore::loggers
+
   concat::fragment { 'logging':
     target  => 'pulpcore settings',
     content => epp('pulpcore/settings-logging.py.epp', {
         'level'   => $pulpcore::log_level,
-        'loggers' => $pulpcore::loggers,
+        'loggers' => $loggers,
     }),
     order   => '02',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,10 @@
 #   The number of seconds that content should be cached for. Specify 'None' to never expire the cache.
 #
 # @param log_level
-#   Sets the log level.
+#   Sets the log level for the root logger.
+#
+# @param loggers
+#   Configure additional loggers or override pre-defined logger configuration.
 #
 # @example Default configuration
 #   include pulpcore
@@ -223,7 +226,8 @@ class pulpcore (
   Hash[String[1], String[1]] $api_client_auth_cn_map = {},
   Boolean $cache_enabled = false,
   Optional[Variant[Integer[1], Enum['None']]] $cache_expires_ttl = undef,
-  Enum['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'] $log_level = 'INFO',
+  Pulpcore::LogLevel $log_level = 'INFO',
+  Hash[String[1], Pulpcore::Logger] $loggers = {},
 ) {
   $settings_file = "${config_dir}/settings.py"
   $certs_dir = "${config_dir}/certs"

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -34,7 +34,7 @@ describe 'pulpcore' do
                     '': {
                         'handlers': ['console'],
                         'level': 'INFO',
-                    }
+                    },
                     'pulpcore.deprecation': {
                         'handlers': ['console'],
                         'level': 'ERROR',
@@ -45,7 +45,7 @@ describe 'pulpcore' do
                         'level': 'WARNING',
                         'propagate': False,
                     },
-                }
+                },
             }
           LOGGING
           is_expected.to contain_file('/etc/pulp')
@@ -546,7 +546,7 @@ CONTENT
                     '': {
                         'handlers': ['console'],
                         'level': 'DEBUG',
-                    }
+                    },
                     'pulpcore.deprecation': {
                         'handlers': ['console'],
                         'level': 'INFO',
@@ -562,7 +562,7 @@ CONTENT
                         'level': 'CRITICAL',
                         'propagate': False,
                     },
-                }
+                },
             }
           LOGGING
         end

--- a/spec/type_aliases/logger.rb
+++ b/spec/type_aliases/logger.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Pulpcore::Logger' do
+  it { is_expected.to allow_value({level: 'CRITICAL'}) }
+  it { is_expected.not_to allow_value({}) }
+  it { is_expected.not_to allow_value(nil) }
+end

--- a/spec/type_aliases/loglevel.rb
+++ b/spec/type_aliases/loglevel.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'Pulpcore::LogLevel' do
+  it { is_expected.to allow_value('CRITICAL') }
+  it { is_expected.to allow_value('ERROR') }
+  it { is_expected.to allow_value('WARNING') }
+  it { is_expected.to allow_value('INFO') }
+  it { is_expected.to allow_value('DEBUG') }
+  it { is_expected.not_to allow_value('') }
+end

--- a/templates/settings-logging.py.epp
+++ b/templates/settings-logging.py.epp
@@ -1,0 +1,19 @@
+<%- | Pulpcore::LogLevel $level,
+      Hash[String[1], Pulpcore::Logger] $loggers
+| -%>
+LOGGING = {
+    "dynaconf_merge": True,
+    "loggers": {
+        '': {
+            'handlers': ['console'],
+            'level': '<%= $level %>',
+        }
+        <%- $loggers.each |$logger, $properties| { -%>
+        '<%= $logger %>': {
+            'handlers': ['console'],
+            'level': '<%= $properties['level'] %>',
+            'propagate': False,
+        },
+        <%- } -%>
+    }
+}

--- a/templates/settings-logging.py.epp
+++ b/templates/settings-logging.py.epp
@@ -7,7 +7,7 @@ LOGGING = {
         '': {
             'handlers': ['console'],
             'level': '<%= $level %>',
-        }
+        },
         <%- $loggers.each |$logger, $properties| { -%>
         '<%= $logger %>': {
             'handlers': ['console'],
@@ -15,5 +15,5 @@ LOGGING = {
             'propagate': False,
         },
         <%- } -%>
-    }
+    },
 }

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -62,13 +62,3 @@ CACHE_SETTINGS = {
     'EXPIRES_TTL': <%= scope['pulpcore::cache_expires_ttl'] %>,
 }
 <% end -%>
-
-LOGGING = {
-    "dynaconf_merge": True,
-    "loggers": {
-        '': {
-            'handlers': ['console'],
-            'level': '<%= scope['pulpcore::log_level'] %>',
-        }
-    }
-}

--- a/types/logger.pp
+++ b/types/logger.pp
@@ -1,0 +1,3 @@
+type Pulpcore::Logger = Struct[{
+  level => Pulpcore::LogLevel,
+}]

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,0 +1,1 @@
+type Pulpcore::LogLevel = Enum['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']


### PR DESCRIPTION
This introduces the ability to specify arbitrary loggers with their own log level. While there is currently only a single option, this prepares for future extension.

Additionally, there are default loggers added for pulpcore.deprecation and django_guid. Their levels can still be overridden using the loggers parameter.