### PR TITLE
Add pulpcore 3.21 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
         puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         pulpcore_version:
+          - '3.21'
           - '3.18'
           - '3.17'
           - '3.16'

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.18
+### Pulpcore 3.21
 
 Default recommended version.
+
+### Pulpcore 3.18
+
+Supported version.
 
 ### Pulpcore 3.17
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.18',
+  Pattern['^\d+\.\d+$'] $version = '3.21',
 ) {
   $dist_tag = "el${facts['os']['release']['major']}"
   $context = {

--- a/spec/support/acceptance/examples.rb
+++ b/spec/support/acceptance/examples.rb
@@ -56,7 +56,11 @@ shared_examples 'the default pulpcore application' do
 
   describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/", cacert: "#{certdir}/ca-cert.pem") do
     # Requires authentication: https://github.com/pulp/pulpcore/issues/2340
-    its(:response_code) { is_expected.to eq(403) }
+    if(!['3.16', '3.17', '3.18', '3.19'].include?(ENV['BEAKER_FACTER_PULPCORE_VERSION']))
+      its(:response_code) { is_expected.to eq(200) }
+    else
+      its(:response_code) { is_expected.to eq(403) }
+    end
     its(:exit_status) { is_expected.to eq 0 }
   end
 


### PR DESCRIPTION
Adding pulpcore 3.21 since we have that packaged. Working on other bits to enable this in katello and gems packaging.