### PR TITLE
Expose Apache server aliases as a parameter

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -82,6 +82,7 @@ class pulpcore::apache (
       include apache::mod::headers
       apache::vhost { $http_vhost_name:
         servername     => $pulpcore::servername,
+        serveraliases  => $pulpcore::serveraliases,
         port           => $http_port,
         priority       => $vhost_priority,
         docroot        => $pulpcore::apache_docroot,
@@ -111,6 +112,7 @@ class pulpcore::apache (
       include apache::mod::headers
       apache::vhost { $https_vhost_name:
         servername        => $pulpcore::servername,
+        serveraliases     => $pulpcore::serveraliases,
         port              => $https_port,
         ssl               => true,
         priority          => $vhost_priority,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,6 +115,9 @@
 # @param servername
 #   Server name of the VirtualHost in the webserver
 #
+# @param serveraliases
+#   Server aliases of the VirtualHost in the webserver
+#
 # @param remote_user_environ_name
 #   Django remote user environment variable
 #
@@ -217,6 +220,7 @@ class pulpcore (
   String $django_secret_key = extlib::cache_data('pulpcore_cache_data', 'secret_key', extlib::random_password(50)),
   Integer[0] $redis_db = 8,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
+  Array[Stdlib::Fqdn] $serveraliases = [],
   Array[Stdlib::Absolutepath] $allowed_import_path = ['/var/lib/pulp/sync_imports'],
   Array[Stdlib::Absolutepath] $allowed_export_path = [],
   Pulpcore::ChecksumTypes $allowed_content_checksums = ['sha224', 'sha256', 'sha384', 'sha512'],

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -79,7 +79,6 @@ describe 'pulpcore' do
         it 'configures apache' do
           is_expected.to contain_class('pulpcore::apache')
           is_expected.to contain_apache__vhost('pulpcore')
-          is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-pulpcore')
             .with_directories([
               {
                 'provider'       => 'Directory',
@@ -100,6 +99,7 @@ describe 'pulpcore' do
                 ],
               },
             ])
+          is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-pulpcore')
           is_expected.to contain_apache__vhost('pulpcore-https')
             .with_directories([
               {

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -79,6 +79,7 @@ describe 'pulpcore' do
         it 'configures apache' do
           is_expected.to contain_class('pulpcore::apache')
           is_expected.to contain_apache__vhost('pulpcore')
+            .with_serveraliases([])
             .with_directories([
               {
                 'provider'       => 'Directory',
@@ -101,6 +102,7 @@ describe 'pulpcore' do
             ])
           is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-pulpcore')
           is_expected.to contain_apache__vhost('pulpcore-https')
+            .with_serveraliases([])
             .with_directories([
               {
                 'path'           => '/var/lib/pulp/pulpcore_static',


### PR DESCRIPTION
This allows setting a CNAME.

Passing the aliases to Apache is especially important when there are multiple vhosts or when using mod_md. While today we don't do either, having the option is good. It can also help with debugging since sosreport does collect the vhosts, but not the certificates. If ServerAliases matches what's on the certificate, that can give a hint.

Currently still working on tests.