### PR TITLE
Remove unused CONTENT_HOST setting

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -17,7 +17,6 @@
 TELEMETRY = <%= scope.call_function('to_python', [scope['pulpcore::telemetry']]) %>
 <% end -%>
 
-CONTENT_HOST = "<%= scope['pulpcore::servername'] %>"
 CONTENT_ORIGIN = "https://<%= scope['pulpcore::servername'] %>"
 SECRET_KEY = "<%= scope['pulpcore::django_secret_key'] %>"
 DATABASES = {


### PR DESCRIPTION
Since Pulpcore 3.0.0 this setting has been [replaced by CONTENT_ORIGIN](https://pulp.plan.io/issues/5649).