### PR TITLE
Add param for unsafe advisory conflict resolution

### DIFF
--- a/manifests/plugin/rpm.pp
+++ b/manifests/plugin/rpm.pp
@@ -6,9 +6,14 @@
 #   Pulpcore's KEEP_CHANGELOG_LIMIT setting. Uses Pulpcore's default when
 #   undefined. Increasing this limit will cause pulpcore workers to use more
 #   memory when more changelogs are available in the repo metadata.
+#
+# @param allow_automatic_unsafe_advisory_conflict_resolution
+#   Allow resolving of conflicts due to duplicate advisory ids with different creation dates
+#   https://docs.pulpproject.org/pulp_rpm/settings.html#allow-automatic-unsafe-advisory-conflict-resolution
 class pulpcore::plugin::rpm (
   Boolean $use_pulp2_content_route = false,
   Optional[Integer[0]] $keep_changelog_limit = undef,
+  Boolean $allow_automatic_unsafe_advisory_conflict_resolution = false,
 ) {
   if $use_pulp2_content_route {
     $context = {
@@ -34,8 +39,11 @@ class pulpcore::plugin::rpm (
     $content = undef
   }
 
-  if $keep_changelog_limit {
-    $rpm_plugin_config = "KEEP_CHANGELOG_LIMIT = ${keep_changelog_limit}"
+  if $keep_changelog_limit or $allow_automatic_unsafe_advisory_conflict_resolution {
+    $rpm_plugin_config = epp('pulpcore/settings-rpm.py.epp', {
+        'allow_auacr'          => $allow_automatic_unsafe_advisory_conflict_resolution,
+        'keep_changelog_limit' => $keep_changelog_limit,
+    })
   } else {
     $rpm_plugin_config = undef
   }

--- a/spec/classes/plugin_rpm_spec.rb
+++ b/spec/classes/plugin_rpm_spec.rb
@@ -22,13 +22,23 @@ describe 'pulpcore::plugin::rpm' do
           is_expected.not_to contain_concat__fragment('plugin-rpm')
         end
 
+        context 'with allow_unsafe_advisory_conflict_resolution' do
+          let(:params) { { allow_automatic_unsafe_advisory_conflict_resolution: true } }
+
+          it 'configures pulpcore with ALLOW_AUTOMATIC_UNSAFE_ADVISORY_CONFLICT_RESOLUTION' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat__fragment('plugin-rpm')
+              .with_content("\n# rpm plugin settings\nALLOW_AUTOMATIC_UNSAFE_ADVISORY_CONFLICT_RESOLUTION = True\n")
+          end
+        end
+
         context 'with keep_changelog_limit' do
           let(:params) { { keep_changelog_limit: 20 } }
 
           it 'configures pulpcore with KEEP_CHANGELOG_LIMIT' do
             is_expected.to compile.with_all_deps
             is_expected.to contain_concat__fragment('plugin-rpm')
-              .with_content("\n# rpm plugin settings\nKEEP_CHANGELOG_LIMIT = 20")
+              .with_content("\n# rpm plugin settings\nKEEP_CHANGELOG_LIMIT = 20\n")
           end
         end
 

--- a/templates/settings-rpm.py.epp
+++ b/templates/settings-rpm.py.epp
@@ -1,0 +1,9 @@
+<%- | Boolean $allow_auacr,
+      Optional[Integer[0]] $keep_changelog_limit
+| -%>
+<%- if $keep_changelog_limit { -%>
+KEEP_CHANGELOG_LIMIT = <%= $keep_changelog_limit %>
+<%- } -%>
+<%- if $allow_auacr { -%>
+ALLOW_AUTOMATIC_UNSAFE_ADVISORY_CONFLICT_RESOLUTION = True
+<%- } -%>


### PR DESCRIPTION
https://community.theforeman.org/t/katello-incoming-and-existing-advisories-have-the-same-id-but-different-timestamps/23954/8