### PR TITLE
Fixes #36030 - Ensure HStore is enabled for Pulp 3.22 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
         puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         pulpcore_version:
+          - '3.22'
           - '3.21'
           - '3.18'
           - '3.17'

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.21
+### Pulpcore 3.22
 
 Default recommended version.
+
+### Pulpcore 3.21
+
+Supported version
 
 ### Pulpcore 3.18
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -6,12 +6,19 @@ class pulpcore::database (
   if $pulpcore::postgresql_manage_db {
     include postgresql::client
     include postgresql::server
+    include postgresql::server::contrib
     postgresql::server::db { $pulpcore::postgresql_db_name:
       user     => $pulpcore::postgresql_db_user,
       password => postgresql::postgresql_password($pulpcore::user, $pulpcore::postgresql_db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
       before   => Pulpcore::Admin['migrate --noinput'],
+    }
+
+    postgresql::server::extension { "hstore for ${pulpcore::postgresql_db_name}":
+      database  => $pulpcore::postgresql_db_name,
+      extension => 'hstore',
+      require   => Class['postgresql::server::contrib'],
     }
 
     # pulpcore-content fails to reconnect to the database, so schedule a restart whenever the db changes

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 # @param version
 #   The Pulpcore version to use
 class pulpcore::repo (
-  Pattern['^\d+\.\d+$'] $version = '3.21',
+  Pattern['^\d+\.\d+$'] $version = '3.22',
 ) {
   $dist_tag = "el${facts['os']['release']['major']}"
   $context = {


### PR DESCRIPTION
Pulpcore 3.22 will [start using HStore](https://github.com/pulp/pulpcore/pull/3427), which is in postgresql-contrib. This ensures it's installed.

This is all theoretical and I haven't tested this out yet. Just making sure this is tracked somehow.