### PR TITLE
Drop Pulpcore 3.16 - 3.18, add EL 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
         pulpcore_version:
           - '3.22'
           - '3.21'
-          - '3.18'
-          - '3.17'
-          - '3.16'
     name: Acceptance / ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }} - Pulp ${{ matrix.pulpcore_version }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -18,17 +18,9 @@ Default recommended version.
 
 Supported version
 
-### Pulpcore 3.18
+### Pulpcore 3.16 - 3.18
 
-Supported version.
-
-### Pulpcore 3.17
-
-Supported version.
-
-### Pulpcore 3.16
-
-Supported version.
+Untested, but should work. Not recommended.
 
 ## Installation layout
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,13 +20,16 @@ class pulpcore::repo (
     notify  => Anchor['pulpcore::repo'],
   }
 
-  package { 'pulpcore-dnf-module':
-    ensure      => $dist_tag,
-    name        => 'pulpcore',
-    enable_only => true,
-    provider    => 'dnfmodule',
-    require     => File['/etc/yum.repos.d/pulpcore.repo'],
-    notify      => Anchor['pulpcore::repo'],
+  # Only EL8 has DNF modules
+  if $dist_tag == 'el8' {
+    package { 'pulpcore-dnf-module':
+      ensure      => $dist_tag,
+      name        => 'pulpcore',
+      enable_only => true,
+      provider    => 'dnfmodule',
+      require     => File['/etc/yum.repos.d/pulpcore.repo'],
+      notify      => Anchor['pulpcore::repo'],
+    }
   }
 
   # An anchor is used because it can be collected

--- a/metadata.json
+++ b/metadata.json
@@ -39,13 +39,15 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -13,14 +13,18 @@ describe 'pulpcore::repo' do
           .that_notifies('Anchor[pulpcore::repo]')
       end
 
-      it 'configures the pulpcore module' do
-        is_expected.to contain_package('pulpcore-dnf-module')
-          .with_name('pulpcore')
-          .with_ensure(/^el\d+/)
-          .with_enable_only(true)
-          .with_provider('dnfmodule')
-          .that_requires('File[/etc/yum.repos.d/pulpcore.repo]')
-          .that_notifies('Anchor[pulpcore::repo]')
+      if os_facts[:os]['release']['major'] == '8'
+        it 'configures the pulpcore module' do
+          is_expected.to contain_package('pulpcore-dnf-module')
+            .with_name('pulpcore')
+            .with_ensure(/^el\d+/)
+            .with_enable_only(true)
+            .with_provider('dnfmodule')
+            .that_requires('File[/etc/yum.repos.d/pulpcore.repo]')
+            .that_notifies('Anchor[pulpcore::repo]')
+        end
+      else
+        it { is_expected.not_to contain_package('pulpcore-dnf-module') }
       end
     end
   end


### PR DESCRIPTION
While it doesn't modify any code, does reduce the testing matrix. It's also chosen because 3.21 and 3.22 have EL9 and that keeps the tesing matrix easier.

Currently untested, going to rely on CI.