### PR TITLE
Pin Puppet in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: development:test:release
+      PUPPET_GEM_VERSION: '~> 7.24'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       puppet_unit_test_matrix: ${{ steps.get_outputs.outputs.puppet_unit_test_matrix }}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
+      PUPPET_GEM_VERSION: '~> 7.24'
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -42,7 +43,7 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
     env:
       BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
+      PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.24"
     name: Unit / Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Puppet 8.0.0 was released with incorrect Ruby compatibility metadata, which confuses bundler. This pins to more specific versions.

In gha-puppet this was already done, but this module has a modified beaker pipeline (to run multiple Pulpcore versions) so doesn't benefit from it.