### PR TITLE
use `--workers` instead of `-w` when configuring gunicorn workers

### DIFF
--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -149,7 +149,7 @@ describe 'pulpcore' do
           is_expected.to contain_class('pulpcore::service')
           is_expected.to contain_pulpcore__socket_service('pulpcore-api')
           is_expected.to contain_systemd__unit_file('pulpcore-api.socket')
-          is_expected.to contain_systemd__unit_file('pulpcore-api.service').with_content(%r{-w 2})
+          is_expected.to contain_systemd__unit_file('pulpcore-api.service').with_content(%r{--workers 2})
           is_expected.to contain_file('/etc/systemd/system/pulpcore-api.socket').that_comes_before('Service[pulpcore-api.service]')
           is_expected.to contain_pulpcore__socket_service('pulpcore-content')
           is_expected.to contain_systemd__unit_file('pulpcore-content.socket')

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -13,7 +13,7 @@ WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-api
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.app.wsgi:application \
           --timeout <%= scope['pulpcore::api_service_worker_timeout'] %> \
-          -w <%= scope['pulpcore::api_service_worker_count'] %> \
+          --workers <%= scope['pulpcore::api_service_worker_count'] %> \
           --access-logfile - \
           --access-logformat 'pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 ExecReload=/bin/kill -s HUP $MAINPID

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -14,7 +14,7 @@ RuntimeDirectory=pulpcore-content
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
           --timeout <%= scope['pulpcore::content_service_worker_timeout'] %> \
           --worker-class 'aiohttp.GunicornWebWorker' \
-          -w <%= scope['pulpcore::content_service_worker_count'] %> \
+          --workers <%= scope['pulpcore::content_service_worker_count'] %> \
           --access-logfile -
 ExecReload=/bin/kill -s HUP $MAINPID
 SyslogIdentifier=pulpcore-content


### PR DESCRIPTION
long options are easier to read and understand