### PR TITLE
Fixes #36437 - preload pulpcore API and content code

### DIFF
--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -12,6 +12,7 @@ Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-api
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.app.wsgi:application \
+          --preload \
           --timeout <%= scope['pulpcore::api_service_worker_timeout'] %> \
           -w <%= scope['pulpcore::api_service_worker_count'] %> \
           --access-logfile - \

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -12,6 +12,7 @@ Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-content
 ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
+          --preload \
           --timeout <%= scope['pulpcore::content_service_worker_timeout'] %> \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w <%= scope['pulpcore::content_service_worker_count'] %> \


### PR DESCRIPTION
this reduces the overall memory usage by keeping only one copy of the code, instead of N (= number of workers).

unscientific benchmark says that with 5 API and 17 content workers, this reduces the memory footprint from 500MiB to 125MiB and from 1.5GiB to 500MiB respectively.

those numbers are obviously before any actual work is executed and memory consumed by the app itself.