### PR TITLE
allow puppet/redis 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 5.0.0 < 9.0.0"
+      "version_requirement": ">= 5.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
the breaking changes are dropping Debian 9 and Puppet 6, which is fine for us