### PR TITLE
Fixes #36709 - Set empty ANSIBLE_PERMISSION_CLASSES setting to turn off RBAC for galaxy endpoints

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -26,7 +26,7 @@ class pulpcore::plugin::ansible (
   }
 
   pulpcore::plugin { 'ansible':
-    config        => "ANSIBLE_API_HOSTNAME = \"${external_api_url}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}\"",
+    config        => "ANSIBLE_API_HOSTNAME = \"${external_api_url}\"\nANSIBLE_CONTENT_HOSTNAME = \"${external_content_url}\"\nANSIBLE_PERMISSION_CLASSES = []",
     https_content => epp('pulpcore/apache-fragment.epp', $context),
   }
 }


### PR DESCRIPTION
Prepping for this: https://github.com/pulp/pulp_ansible/pull/1561

We need to set ANSIBLE_PERMISSION_CLASSES = [] to turn off RBAC for galaxy endpoints to allow capsule syncs for ansible repos.