### PR TITLE
Remove leftover from testing Pulpcore < 3.20

### DIFF
--- a/spec/support/acceptance/examples.rb
+++ b/spec/support/acceptance/examples.rb
@@ -55,12 +55,7 @@ shared_examples 'the default pulpcore application' do
   end
 
   describe curl_command("https://#{host_inventory['fqdn']}/pulp/api/v3/", cacert: "#{certdir}/ca-cert.pem") do
-    # Requires authentication: https://github.com/pulp/pulpcore/issues/2340
-    if(!['3.16', '3.17', '3.18', '3.19'].include?(ENV['BEAKER_FACTER_PULPCORE_VERSION']))
-      its(:response_code) { is_expected.to eq(200) }
-    else
-      its(:response_code) { is_expected.to eq(403) }
-    end
+    its(:response_code) { is_expected.to eq(200) }
     its(:exit_status) { is_expected.to eq 0 }
   end
 


### PR DESCRIPTION
Fixes: e93f305df5ae ("Drop testing for Pulpcore 3.16 - 3.18")