### PR TITLE
Fixes #36902 - Support Pulpcore 3.39, drop older versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: 'false'
-      beaker_facter: 'pulpcore_version:Pulp:3.28,3.22,3.21'
+      beaker_facter: 'pulpcore_version:Pulp:nightly,3.39'
       rubocop: false
       cache-version: '1'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,3 @@
 ---
 .github/workflows/ci.yml:
-  beaker_facter: 'pulpcore_version:Pulp:3.28,3.22,3.21'
+  beaker_facter: 'pulpcore_version:Pulp:nightly,3.39'

--- a/README.md
+++ b/README.md
@@ -10,21 +10,9 @@ All supported versions are listed below. For every supported version, acceptance
 
 Supported operating systems are listed in `metadata.json` but individual releases can divert from that. For example, if Pulpcore x.y drops EL7, it will still be listed in metadata.json until all versions supported by the module have dropped it. Similarly, if x.z adds support for EL9, it'll be listed in `metadata.json` and all versions that don't support EL9 will have a note.
 
-### Pulpcore 3.28
+### Pulpcore 3.39
 
 Default recommended version.
-
-### Pulpcore 3.22
-
-Supported version.
-
-### Pulpcore 3.21
-
-Supported version. The parameter `$hide_guarded_distributions` doesn't work since it's a Pulp 3.22 feature.
-
-### Pulpcore 3.16 - 3.18
-
-Untested, but should work besides the `$hide_guarded_distributions` parameter. Not recommended.
 
 ## Installation layout
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -8,7 +8,7 @@
 #   An optional value for gpgkey to be used for yumrepo, instead of the default.
 #   If an empty string is passed, gpgcheck will be disabled.
 class pulpcore::repo (
-  Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $version = '3.28',
+  Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $version = '3.39',
   Optional[Stdlib::HTTPUrl] $baseurl = undef,
   Optional[String[0]] $gpgkey = undef,
 ) {
@@ -18,21 +18,9 @@ class pulpcore::repo (
     descr    => "Pulpcore ${version}",
     baseurl  => pick($baseurl, "https://yum.theforeman.org/pulpcore/${version}/${dist_tag}/\$basearch"),
     enabled  => '1',
-    gpgcheck => if $gpgkey == '' { '0' } else { '1' },
+    gpgcheck => if $gpgkey == '' or $version == 'nightly' { '0' } else { '1' },
     gpgkey   => pick($gpgkey, "https://yum.theforeman.org/pulpcore/${version}/GPG-RPM-KEY-pulpcore"),
     notify   => Anchor['pulpcore::repo'],
-  }
-
-  # Only EL8 has DNF modules
-  if $dist_tag == 'el8' {
-    package { 'pulpcore-dnf-module':
-      ensure      => $dist_tag,
-      name        => 'pulpcore',
-      enable_only => true,
-      provider    => 'dnfmodule',
-      require     => Yumrepo['pulpcore'],
-      notify      => Anchor['pulpcore::repo'],
-    }
   }
 
   # An anchor is used because it can be collected

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -14,20 +14,6 @@ describe 'pulpcore::repo' do
           .with_gpgkey(%r{https://yum.theforeman.org/pulpcore/\d+\.\d+/GPG-RPM-KEY-pulpcore})
           .that_notifies('Anchor[pulpcore::repo]')
         }
-
-        if os_facts[:os]['release']['major'] == '8'
-          it 'configures the pulpcore module' do
-            is_expected.to contain_package('pulpcore-dnf-module')
-              .with_name('pulpcore')
-              .with_ensure(/^el\d+/)
-              .with_enable_only(true)
-              .with_provider('dnfmodule')
-              .that_requires('Yumrepo[pulpcore]')
-              .that_notifies('Anchor[pulpcore::repo]')
-          end
-        else
-          it { is_expected.not_to contain_package('pulpcore-dnf-module') }
-        end
       end
 
       describe "with nightly version" do

--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -11,7 +11,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-api
-ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.app.wsgi:application \
+ExecStart=/usr/bin/pulpcore-api \
           --preload \
           --timeout <%= scope['pulpcore::api_service_worker_timeout'] %> \
           --workers <%= scope['pulpcore::api_service_worker_count'] %> \

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -11,10 +11,9 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-content
-ExecStart=/usr/libexec/pulpcore/gunicorn pulpcore.content:server \
+ExecStart=/usr/bin/pulpcore-content \
           --preload \
           --timeout <%= scope['pulpcore::content_service_worker_timeout'] %> \
-          --worker-class 'aiohttp.GunicornWebWorker' \
           --workers <%= scope['pulpcore::content_service_worker_count'] %> \
           --access-logfile -
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
Assumes that https://github.com/pulp/pulpcore/issues/4679 is in Pulpcore 3.39.

Also assumes that https://github.com/pulp/pulpcore/issues/4681 is going to be fixed for Pulpcore 3.39 in time. This doesn't affect the installer but we shouldn't release Katello with that Pulpcore bug.

I had to assume that the entry point will live in `/usr/bin` since, when installed via `pip`, it is installed to `/usr/local/bin`.

I verified these work (minus the jitter for now):

```
ExecStart=/usr/local/bin/pulpcore-api --preload --timeout 90 --workers 5 --max-requests 800 --access-logfile - --access-logformat 'pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
```

and

```
ExecStart=/usr/local/bin/pulpcore-content  --preload --timeout 90  --workers 5 --access-logfile -
```