### PR TITLE
Declare cli.toml files as managed via Puppet

### DIFF
--- a/templates/cli-config.toml.epp
+++ b/templates/cli-config.toml.epp
@@ -8,6 +8,7 @@
   Optional[Boolean]         $verify_ssl = undef,
   Optional[Boolean]         $dry_run = undef,
 | -%>
+# This file is managed by puppet-pulpcore. Manual edits will be overwritten with the next run.
 [cli]
 <% if $base_url { -%>
 base_url = "<%= $base_url %>"


### PR DESCRIPTION
This would have saved us some confusion (though we did suspect foreman-installer had started overwriting our config pretty quickly).

I am not attached to the precise wording or formatting.

The idea is similar to https://github.com/theforeman/puppet-pulpcore/pull/210 but for the `cli.toml` files written by this module.

Not a Puppet expert so I am opening this as a draft PR in the expectation that it needs further changes to achieve best practice, tests, etc.