### PR TITLE
Fixes #37062 - Rename pulpcore::telemetry to pulpcore::analytics

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,11 +183,11 @@
 # @param loggers
 #   Configure additional loggers or override pre-defined logger configuration.
 #
-# @param telemetry
-#   Configure TELEMETRY in settings.yml, which controls the reporting of anonymous data to https://analytics.pulpproject.org/,
+# @param analytics
+#   Configure ANALYTICS in settings.yml, which controls the reporting of anonymous data to https://analytics.pulpproject.org/,
 #   starting with Pulpcore version 3.21.0, to guide Pulp project developers. Set this to false to opt out of this anonymous reporting;
 #   if undef, it will instead be omitted from settings.yml and Pulp will report these usage statistics per its default behavior.
-#   Adding this configuration will have no effect in Pulp versions prior to the introduction of the telemetry feature.
+#   Originally, the pulp setting was called TELEMETRY and this param was called telemetry; it was renamed by the pulp developers.
 #
 # @param hide_guarded_distributions
 #   If activated, the distributions that are protected by a content guard will not be shown on the
@@ -254,7 +254,7 @@ class pulpcore (
   Optional[Variant[Integer[1], Enum['None']]] $cache_expires_ttl = undef,
   Pulpcore::LogLevel $log_level = 'INFO',
   Hash[String[1], Pulpcore::Logger] $loggers = {},
-  Optional[Boolean] $telemetry = undef,
+  Optional[Boolean] $analytics = undef,
   Optional[Boolean] $hide_guarded_distributions = undef,
   Optional[Integer[1,100]] $import_workers_percent = undef,
 ) {

--- a/spec/acceptance/settings_spec.rb
+++ b/spec/acceptance/settings_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'ANALYTICS setting' do
-  context 'default ANALYTICS' do
-    it_behaves_like 'an idempotent resource' do
-      let(:manifest) do
-        <<-PUPPET
-        include pulpcore
-        PUPPET
-      end
-    end
-
-    describe file('/etc/pulp/settings.py') do
-      it { is_expected.to be_file }
-      its(:content) { is_expected.to match(/^# ANALYTICS = False$/) }
-    end
-  end
-
   context 'ANALYTICS disabled' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do

--- a/spec/acceptance/settings_spec.rb
+++ b/spec/acceptance/settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
-describe 'TELEMETRY setting' do
-  context 'default TELEMETRY' do
+describe 'ANALYTICS setting' do
+  context 'default ANALYTICS' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do
         <<-PUPPET
@@ -12,16 +12,16 @@ describe 'TELEMETRY setting' do
 
     describe file('/etc/pulp/settings.py') do
       it { is_expected.to be_file }
-      its(:content) { is_expected.to match(/^# TELEMETRY = False$/) }
+      its(:content) { is_expected.to match(/^# ANALYTICS = False$/) }
     end
   end
 
-  context 'TELEMETRY disabled' do
+  context 'ANALYTICS disabled' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do
         <<-PUPPET
         class { 'pulpcore':
-          telemetry => false,
+          analytics => false,
         }
         PUPPET
       end
@@ -29,16 +29,16 @@ describe 'TELEMETRY setting' do
 
     describe file('/etc/pulp/settings.py') do
       it { is_expected.to be_file }
-      its(:content) { is_expected.to match(/^TELEMETRY = False$/) }
+      its(:content) { is_expected.to match(/^ANALYTICS = False$/) }
     end
   end
 
-  context 'TELEMETRY enabled' do
+  context 'ANALYTICS enabled' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do
         <<-PUPPET
         class { 'pulpcore':
-          telemetry => true,
+          analytics => true,
         }
         PUPPET
       end
@@ -46,7 +46,7 @@ describe 'TELEMETRY setting' do
 
     describe file('/etc/pulp/settings.py') do
       it { is_expected.to be_file }
-      its(:content) { is_expected.to match(/^TELEMETRY = True$/) }
+      its(:content) { is_expected.to match(/^ANALYTICS = True$/) }
     end
   end
 end

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -25,6 +25,7 @@ describe 'pulpcore' do
             .with_content(%r{ALLOWED_CONTENT_CHECKSUMS = \["sha224", "sha256", "sha384", "sha512"\]})
             .with_content(%r{REDIS_URL = "redis://localhost:6379/8"})
             .with_content(%r{CACHE_ENABLED = False})
+            .with_content(%r{# ANALYTICS = False})
             .without_content(%r{sslmode})
             .without_content(%r{WORKER_TTL})
           is_expected.to contain_concat__fragment('logging').with_content(<<~LOGGING)

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -11,10 +11,10 @@
 # Send anonymous usage data to https://analytics.pulpproject.org/ unless this is
 # explicitly defined with value False. This data is used by the Pulp project
 # to make informed, data-driven decisions about future feature development.
-<% if scope['pulpcore::telemetry'].nil? -%>
-# TELEMETRY = False
+<% if scope['pulpcore::analytics'].nil? -%>
+# ANALYTICS = False
 <% else -%>
-TELEMETRY = <%= scope.call_function('to_python', [scope['pulpcore::telemetry']]) %>
+ANALYTICS = <%= scope.call_function('to_python', [scope['pulpcore::analytics']]) %>
 <% end -%>
 
 CONTENT_ORIGIN = "https://<%= scope['pulpcore::servername'] %>"


### PR DESCRIPTION
Pulp changed the setting name to ANALYTICS. The original name TELEMETRY is deprecated and could be removed in the future. Using pulp's preferred name will also remove the deprecation warning that appears in logs.