### PR TITLE
Ensure glibc-langpack-en is always installed

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -7,12 +7,14 @@ class pulpcore::database (
     include postgresql::client
     include postgresql::server
     include postgresql::server::contrib
+    ensure_packages(['glibc-langpack-en'])
     postgresql::server::db { $pulpcore::postgresql_db_name:
       user     => $pulpcore::postgresql_db_user,
       password => postgresql::postgresql_password($pulpcore::user, $pulpcore::postgresql_db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
       before   => Pulpcore::Admin['migrate --noinput'],
+      require  => Package['glibc-langpack-en'],
     }
 
     postgresql::server::extension { "hstore for ${pulpcore::postgresql_db_name}":

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,14 +1,3 @@
-$major = $facts['os']['release']['major']
-
-case $major {
-  '8': {
-    package { 'glibc-langpack-en':
-      ensure => installed,
-    }
-  }
-  default: {}
-}
-
 class { 'pulpcore::repo':
   version => fact('pulpcore_version'),
 }


### PR DESCRIPTION
Not all systems have this package pre-installed and without it creation of the database will fail.