### PR TITLE
Mark compatible with puppet/redis 10.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 5.0.0 < 10.0.0"
+      "version_requirement": ">= 5.0.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
The breaking change was the removal of Debian 10 support, which doesn't affect this module.