### PR TITLE
Allow puppetlabs/apache 12.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 5.4.0 < 12.0.0"
+      "version_requirement": ">= 5.4.0 < 13.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
We need 12.0.3+ for Puppet 8 support due to https://github.com/puppetlabs/puppetlabs-apache/pull/2525