### PR TITLE
use `migrate --check` not `migrate --plan |grep` check for migrations

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -30,7 +30,7 @@ class pulpcore::database (
 
   pulpcore::admin { 'migrate --noinput':
     timeout     => $timeout,
-    unless      => 'pulpcore-manager migrate --plan | grep "No planned migration operations"',
+    unless      => 'pulpcore-manager migrate --check',
     refreshonly => false,
   }
 


### PR DESCRIPTION
`--check` is available since Django 3.1 and is nicer than having to grep
for a message that can be different in another language.
