### PR TITLE
don't add a trailing slash to pulpcore_url in cli tests

### DIFF
--- a/spec/acceptance/cli_spec.rb
+++ b/spec/acceptance/cli_spec.rb
@@ -6,7 +6,7 @@ describe 'installation of server with cli' do
       <<-PUPPET
       include pulpcore
       class { 'pulpcore::cli':
-        pulpcore_url => "https://${facts['networking']['fqdn']}/",
+        pulpcore_url => "https://${facts['networking']['fqdn']}",
         cert         => "/etc/pulpcore-certs/client-cert.pem",
         key          => "/etc/pulpcore-certs/client-key.pem",
       }
@@ -58,7 +58,7 @@ describe 'installation of cli only with password' do
     let(:manifest) do
       <<-PUPPET
       class { 'pulpcore::cli':
-        pulpcore_url => "https://${facts['networking']['fqdn']}/",
+        pulpcore_url => "https://${facts['networking']['fqdn']}",
         username     => "admin",
         password     => "changeme",
       }


### PR DESCRIPTION
new cli is more strict and doesn't accept this
