### PR TITLE
fix spec syntax of settings_spec.rb

### DIFF
--- a/spec/acceptance/settings_spec.rb
+++ b/spec/acceptance/settings_spec.rb
@@ -164,6 +164,7 @@ describe 'REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES setting' do
 
     describe file('/etc/pulp/settings.py') do
       it { is_expected.to be_file }
+      its(:content) do
         is_expected.to include <<~EXPECTED
           REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = (
               'rest_framework.authentication.BasicAuthentication',


### PR DESCRIPTION
Fixes: ea88d5efe987d0356e0901f10b2b470ab7432b61
