### PR TITLE
Always run pulpcore-manager migrate

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -30,7 +30,6 @@ class pulpcore::database (
 
   pulpcore::admin { 'migrate --noinput':
     timeout     => $timeout,
-    unless      => 'pulpcore-manager migrate --check',
     refreshonly => false,
   }
 

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -3,3 +3,4 @@ apache::default_mods: false
 pulpcore::apache_https_cert: '/etc/pulpcore-certs/ca-cert.pem'
 pulpcore::apache_https_key: '/etc/pulpcore-certs/ca-key.pem'
 pulpcore::apache_https_ca: '/etc/pulpcore-certs/ca-cert.pem'
+pulpcore::database::always_run_migrations: false


### PR DESCRIPTION
Pulpcore uses post migration hooks to create data in the database, which
sometimes changes even if there are no real migrations to be run.

This is fine from a Django PoV -- post migration hooks run after every
`migrate` call, even if there have been no changes.

However, this means that we need to run `migrate` unconditionally as
otherwise we might miss changes to the hooks (or their data) when there
is no migration attached.

An example of such a change is
https://github.com/pulp/pulpcore/commit/20cffca49de5f3bfac44e0160c1f0fb262141ea5
where a new role was introduced and our setup started failing as it was
expecting the role to exist after the upgrade, but it did not as we did
not call `migrate`.
