### PR TITLE
Reuse headers from pulpcore::apache class

### DIFF
--- a/manifests/plugin/container.pp
+++ b/manifests/plugin/container.pp
@@ -9,14 +9,6 @@ class pulpcore::plugin::container (
   String $location_prefix = '/pulpcore_registry',
   String $registry_version_path = '/v2/',
 ) {
-  $api_default_request_headers = [
-    "unset ${pulpcore::apache::remote_user_environ_header}",
-  ]
-
-  $api_additional_request_headers = $pulpcore::api_client_auth_cn_map.map |String $cn, String $pulp_user| {
-    "set ${pulpcore::apache::remote_user_environ_header} \"${pulp_user}\" \"expr=%{SSL_CLIENT_S_DN_CN} == '${cn}'\""
-  }
-
   $context = {
     'directories' => [
       {
@@ -27,7 +19,7 @@ class pulpcore::plugin::container (
             'url' => "${pulpcore::apache::api_base_url}${registry_version_path}",
           },
         ],
-        'request_headers' => $api_default_request_headers + $api_additional_request_headers,
+        'request_headers' => $pulpcore::apache::api_default_request_headers + $pulpcore::apache::api_additional_request_headers,
       },
     ],
     'proxy_pass'  => [


### PR DESCRIPTION
We have the exact same code in both pulpcore::plugin::container as in pulpcore::apache. This reuses the variables rather than duplicating the logic.

Fixes: 21aa39e28f19 ("Fixes #37308 - set REMOTE_USER properly for pulpcore registry")