### PR TITLE
Correct container plugin apache header rewrite

### DIFF
--- a/manifests/plugin/container.pp
+++ b/manifests/plugin/container.pp
@@ -9,6 +9,11 @@ class pulpcore::plugin::container (
   String $location_prefix = '/pulpcore_registry',
   String $registry_version_path = '/v2/',
 ) {
+  # This is like pulpcore::apache's value, but slightly different
+  $api_default_request_headers = [
+    "unset ${pulpcore::apache::remote_user_environ_header}",
+  ]
+
   $context = {
     'directories' => [
       {
@@ -19,7 +24,7 @@ class pulpcore::plugin::container (
             'url' => "${pulpcore::apache::api_base_url}${registry_version_path}",
           },
         ],
-        'request_headers' => $pulpcore::apache::api_default_request_headers + $pulpcore::apache::api_additional_request_headers,
+        'request_headers' => $api_default_request_headers + $pulpcore::apache::api_additional_request_headers,
       },
     ],
     'proxy_pass'  => [

--- a/spec/classes/plugin_container_spec.rb
+++ b/spec/classes/plugin_container_spec.rb
@@ -16,6 +16,19 @@ describe 'pulpcore::plugin::container' do
         is_expected.to contain_pulpcore__apache__fragment('plugin-container')
         is_expected.not_to contain_apache__vhost__fragment('pulpcore-http-plugin-container')
         is_expected.to contain_apache__vhost__fragment('pulpcore-https-plugin-container')
+          .with_vhost('pulpcore-https')
+          .with_priority('10')
+          .with_content(<<APACHE_CONFIG)
+
+  <Location "/pulpcore_registry/v2/">
+    RequestHeader unset REMOTE_USER
+    ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api/v2/
+    ProxyPassReverse unix:///run/pulpcore-api.sock|http://pulpcore-api/v2/
+  </Location>
+
+  ProxyPass /pulp/container/ unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/container/
+  ProxyPassReverse /pulp/container/ unix:///run/pulpcore-content.sock|http://pulpcore-content/pulp/container/
+APACHE_CONFIG
       end
     end
   end


### PR DESCRIPTION
In 5b6d0885a44d it was assumed that `$api_default_request_headers` was the same, but it was slightly different. This corrects it and adds tests, which should have been added in the first place. These tests pass prior to the application and after, making sure there's no change.

Fixes: 5b6d0885a44d ("Reuse headers from pulpcore::apache class")