### PR TITLE
Add Wants=postgresql.service to Pulpcore service files

### DIFF
--- a/templates/pulpcore-api.service.erb
+++ b/templates/pulpcore-api.service.erb
@@ -2,6 +2,7 @@
 Description=Pulp API Server
 After=network.target
 Requires=pulpcore-api.socket
+Wants=postgresql.service
 
 [Service]
 Type=notify

--- a/templates/pulpcore-content.service.erb
+++ b/templates/pulpcore-content.service.erb
@@ -2,6 +2,7 @@
 Description=Pulp Content App
 Requires=pulpcore-content.socket
 After=network.target
+Wants=postgresql.service
 
 [Service]
 Type=notify

--- a/templates/pulpcore-worker@.service.erb
+++ b/templates/pulpcore-worker@.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=Pulp Worker
 After=network-online.target
-Wants=network-online.target
+Wants=network-online.target postgresql.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Wants is a weak requirement, so the service won't fail it can't be started but systemd will at least try it. That should work with help when postgresql is local.

This was reported in https://github.com/theforeman/foreman_maintain/issues/824. I don't know if this is sufficient or if foreman_maintain also needs to be smarter.

An open question: if we know PostgreSQL is managed, should we make it a hard `Requires=` instead?