### PR TITLE
always compare CNs as downcase

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -53,7 +53,7 @@ class pulpcore::apache (
   ]
 
   $api_additional_request_headers = $pulpcore::api_client_auth_cn_map.map |String $cn, String $pulp_user| {
-    "set ${remote_user_environ_header} \"${pulp_user}\" \"expr=%{SSL_CLIENT_S_DN_CN} == '${cn}'\""
+    "set ${remote_user_environ_header} \"${pulp_user}\" \"expr=%{tolower:%{SSL_CLIENT_S_DN_CN}} == '${cn.downcase}'\""
   }
 
   $api_directory = {

--- a/spec/classes/plugin_container_spec.rb
+++ b/spec/classes/plugin_container_spec.rb
@@ -53,7 +53,7 @@ APACHE_CONFIG
   <Location "/pulpcore_registry">
     RequestHeader unset REMOTE-USER
     RequestHeader unset REMOTE_USER
-    RequestHeader set REMOTE-USER "admin" "expr=%{SSL_CLIENT_S_DN_CN} == 'foreman.example.com'"
+    RequestHeader set REMOTE-USER "admin" "expr=%{tolower:%{SSL_CLIENT_S_DN_CN}} == 'foreman.example.com'"
     ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api
     ProxyPassReverse unix:///run/pulpcore-api.sock|http://pulpcore-api
   </Location>

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -522,7 +522,7 @@ CONTENT
                 'request_headers' => [
                   'unset REMOTE-USER',
                   'unset REMOTE_USER',
-                  'set REMOTE-USER "admin" "expr=%{SSL_CLIENT_S_DN_CN} == \'foreman.example.com\'"',
+                  'set REMOTE-USER "admin" "expr=%{tolower:%{SSL_CLIENT_S_DN_CN}} == \'foreman.example.com\'"',
                 ],
               }
             ])


### PR DESCRIPTION
Sometimes people end up with certificates that have uppercase letters in
the CN, but pass lowercase in the auth map.
