### PR TITLE
use the right username when computing the db password hash

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -11,7 +11,7 @@ class pulpcore::database (
     ensure_packages(['glibc-langpack-en'])
     postgresql::server::db { $pulpcore::postgresql_db_name:
       user     => $pulpcore::postgresql_db_user,
-      password => postgresql::postgresql_password($pulpcore::user, $pulpcore::postgresql_db_password),
+      password => postgresql::postgresql_password($pulpcore::postgresql_db_user, $pulpcore::postgresql_db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
       before   => Pulpcore::Admin['migrate --noinput'],


### PR DESCRIPTION
some people use other names than `pulp` for their DB user
