### PR TITLE
Use pulpcore-worker entrypoint directly, without a wrapper

### DIFF
--- a/templates/pulpcore-worker@.service.erb
+++ b/templates/pulpcore-worker@.service.erb
@@ -13,7 +13,7 @@ User=<%= scope['pulpcore::user'] %>
 Group=<%= scope['pulpcore::group'] %>
 WorkingDirectory=<%= scope['pulpcore::user_home'] %>
 RuntimeDirectory=pulpcore-worker-%i
-ExecStart=/usr/libexec/pulpcore/pulpcore-worker
+ExecStart=/usr/bin/pulpcore-worker
 SyslogIdentifier=pulpcore-worker-%i
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either


### PR DESCRIPTION
Since pulpcore 3.13 the worker has an own "binary" (Python entrypoint), that is correctly labeled as pulpcore_exec_t (since pulpcore-selinux 2.0.1) and thus the workaround with an wrapper is not necessary anymore.

It's actually harmful, as the wrapper is labeled pulpcore_exec_t, so on execution it auto-transitions into pulpcore_t, but then it wants to execute /usr/bin/pulpcore-worker, which is again pulpcore_exec_t but pulpcore_t is not allowed to transition to pulpcore_exec_t and you get

    denied  { execute_no_trans } for comm="pulpcore-worker" path="/usr/bin/pulpcore-worker" scontext=system_u:system_r:pulpcore_t:s0 tcontext=system_u:object_r:pulpcore_exec_t:s0 tclass=file

Fixes: 137128e25b3fda1b3bae0fe0047992100cc6ffe7