### PR TITLE
Fixes #38679 - Handle overlapping import & export paths

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,14 +55,7 @@ class pulpcore::config {
     mode   => '0750',
   }
 
-  file { $pulpcore::allowed_import_path:
-    ensure => directory,
-    owner  => $pulpcore::user,
-    group  => $pulpcore::group,
-    mode   => '0770',
-  }
-
-  file { $pulpcore::allowed_export_path:
+  file { unique($pulpcore::allowed_import_path + $pulpcore::allowed_export_path):
     ensure => directory,
     owner  => $pulpcore::user,
     group  => $pulpcore::group,

--- a/spec/classes/pulpcore_spec.rb
+++ b/spec/classes/pulpcore_spec.rb
@@ -202,6 +202,17 @@ describe 'pulpcore' do
             :group => 'pulp'
           )
         end
+
+        context 'with overlapping allowed export paths' do
+          let(:params) { super().merge(allowed_export_path: ['/tmp/imports', '/tmp/exports']) }
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/tmp/imports')
+            is_expected.to contain_file('/tmp/imports1')
+            is_expected.to contain_file('/tmp/exports')
+          end
+        end
       end
 
       context 'with allowed export paths' do


### PR DESCRIPTION
Without this a duplicate file resource is created.