### PR TITLE
Add apache config support for /pypi

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -1,4 +1,31 @@
 # @summary Pulp Python plugin
 class pulpcore::plugin::python {
-  pulpcore::plugin { 'python': }
+  $pypi_path = '/pypi'
+  $pypi_url = "${pulpcore::apache::api_base_url}${pypi_path}"
+
+  $context = {
+    'directories' => [
+      {
+        'provider'        => 'location',
+        'path'            => $pypi_path,
+        'proxy_pass'      => [
+          {
+            'url'    => $pypi_url,
+            'params' => $pulpcore::apache::api_proxy_params,
+          },
+        ],
+        'request_headers' => [
+          'unset X-CLIENT-CERT',
+          'set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT',
+          'set X-FORWARDED-PROTO expr=%{REQUEST_SCHEME}',
+        ],
+      },
+    ],
+  }
+  $content = epp('pulpcore/apache-fragment.epp', $context)
+
+  pulpcore::plugin { 'python':
+    http_content  => $content,
+    https_content => $content,
+  }
 }

--- a/spec/classes/plugin_python_spec.rb
+++ b/spec/classes/plugin_python_spec.rb
@@ -4,20 +4,30 @@ describe 'pulpcore::plugin::python' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:pre_condition) { 'include pulpcore' }
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_package('pulpcore-plugin(python)') }
       it { is_expected.to contain_pulpcore__plugin('python') }
 
-      context 'with pulpcore' do
-        let(:pre_condition) { 'include pulpcore' }
+      it do
+        is_expected.to contain_pulpcore__plugin('python')
+          .that_subscribes_to('Class[Pulpcore::Install]')
+          .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
+      end
 
-        it do
-          is_expected.to compile.with_all_deps
-          is_expected.to contain_pulpcore__plugin('python')
-            .that_subscribes_to('Class[Pulpcore::Install]')
-            .that_notifies(['Class[Pulpcore::Database]', 'Class[Pulpcore::Service]'])
-        end
+      it do
+        is_expected.to contain_pulpcore__plugin('python')
+          .with_http_content(%r{<Location "/pypi">})
+          .with_http_content(%r{RequestHeader unset X-CLIENT-CERT})
+          .with_http_content(%r{RequestHeader set X-CLIENT-CERT})
+          .with_http_content(%r{RequestHeader set X-FORWARDED-PROTO})
+          .with_http_content(%r{ProxyPass})
+          .with_https_content(%r{<Location "/pypi">})
+          .with_https_content(%r{RequestHeader unset X-CLIENT-CERT})
+          .with_https_content(%r{RequestHeader set X-CLIENT-CERT})
+          .with_https_content(%r{RequestHeader set X-FORWARDED-PROTO})
+          .with_https_content(%r{ProxyPass})
       end
     end
   end


### PR DESCRIPTION
## Summary

Add Apache config support for `/pypi` in puppet-pulpcore

Fixes: [SAT-44474](https://redhat.atlassian.net/browse/SAT-44474)

## Changes                                                                                                                                   
  - Added `use_pypi_route` parameter to `pulpcore::plugin::python` (default: `true`)                                                           
  - Generates Apache `<Location "/pypi">` block that proxies to `pulpcore-api` service
  - Added comprehensive tests for the new parameter

## Generated Apache Config

When `use_pypi_route => true` (default), the module should generate:
```apache                                                                                                                                    
  <Location "/pypi">                                                                                                                           
    RequestHeader unset X-CLIENT-CERT                                                                                                          
    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT                                                                  
    RequestHeader set X-FORWARDED-PROTO expr=%{REQUEST_SCHEME}                                                                                 
    ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api/pypi timeout=600
    ProxyPassReverse unix:///run/pulpcore-api.sock|http://pulpcore-api/pypi                                                                    
  </Location>
```