### PR TITLE
Set database owner to fix PG 15+ schema permissions

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -14,6 +14,7 @@ class pulpcore::database (
       password => postgresql::postgresql_password($pulpcore::postgresql_db_user, $pulpcore::postgresql_db_password),
       encoding => 'utf8',
       locale   => 'en_US.utf8',
+      owner    => $pulpcore::postgresql_db_user,
       before   => Pulpcore::Admin['migrate --noinput'],
       require  => Package['glibc-langpack-en'],
     }


### PR DESCRIPTION
## Summary
- Add `owner` parameter to `postgresql::server::db` resource so the pulpcore database is owned by the `pulp` user instead of `postgres`
- PostgreSQL 15+ revokes `CREATE` on the `public` schema by default — only the database owner retains it
- Without this fix, `pulpcore-manager migrate` fails with `permission denied for schema public` when running against PG 15+

## Root Cause
The `public` schema in PG 15+ is owned by `pg_database_owner`, a special role that maps to the database owner. When the database is owned by `postgres` (the default when `owner` is not set), the `pulp` user has no `CREATE` privilege on the `public` schema and cannot run Django migrations.

Note: `puppet-foreman` already sets `owner` correctly — this aligns `puppet-pulpcore` with that pattern.

## Test plan
- [x] Verified fix on a RHEL 9.8 instance with PG 16 — installer completed successfully after patching this file
- [ ] Existing rspec tests pass (they check resource existence, not parameters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)