### PR TITLE
Add temporary CI job to test Pulpcore nightly on EL10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,15 @@ jobs:
       rubocop: false
 
   # TODO: fold this back into the `puppet` job's beaker_facter matrix once
-  # Pulpcore nightly (and later 3.105) is published for EL10 on
-  # yum.theforeman.org and CentOS/RedHat/AlmaLinux 10 are added to
-  # metadata.json. metadata2gha has no way to run a subset of
-  # beaker_facter values against a subset of operatingsystem_support, so
-  # until then EL10 is tested here against the Copr staging repo instead.
+  # CentOS/RedHat/AlmaLinux 10 are added to metadata.json. metadata2gha has
+  # no way to run a subset of beaker_facter values against a subset of
+  # operatingsystem_support (EL10 will only ever get nightly/3.105+, never
+  # 3.63/3.73/3.85), so until that's resolved EL10 is tested here as a
+  # standalone job instead. See theforeman/el10_rebuild#25.
+  #
+  # Pulpcore nightly is now published for EL10 on yum.theforeman.org, so
+  # pulpcore::repo's defaults (baseurl/gpgcheck) are used as-is - no
+  # Copr staging overrides needed.
   #
   # Uses the openvox8 collection because Puppet doesn't publish an EL10
   # release repo yet (yum.puppet.com/puppet8-release-el-10.noarch.rpm is a
@@ -42,8 +46,6 @@ jobs:
       BEAKER_PUPPET_COLLECTION: openvox8
       BEAKER_SETFILE: 'centos10-64{hostname=centos10-64.example.com}'
       BEAKER_FACTER_pulpcore_version: nightly
-      BEAKER_FACTER_pulpcore_baseurl: https://download.copr.fedorainfracloud.org/results/@theforeman/pulpcore-nightly-staging/rhel-10-x86_64/
-      BEAKER_FACTER_pulpcore_gpgkey: https://download.copr.fedorainfracloud.org/results/@theforeman/pulpcore-nightly-staging/pubkey.gpg
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: disable apparmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,44 @@ jobs:
     with:
       beaker_facter: 'pulpcore_version:Pulp:nightly,3.63,3.73,3.85,3.105'
       rubocop: false
+
+  # TODO: fold this back into the `puppet` job's beaker_facter matrix once
+  # Pulpcore nightly (and later 3.105) is published for EL10 on
+  # yum.theforeman.org and CentOS/RedHat/AlmaLinux 10 are added to
+  # metadata.json. metadata2gha has no way to run a subset of
+  # beaker_facter values against a subset of operatingsystem_support, so
+  # until then EL10 is tested here against the Copr staging repo instead.
+  #
+  # Uses the openvox8 collection because Puppet doesn't publish an EL10
+  # release repo yet (yum.puppet.com/puppet8-release-el-10.noarch.rpm is a
+  # 404), while OpenVox already does (yum.voxpupuli.org).
+  acceptance-el10:
+    name: "Pulp nightly - CentOS Stream 10"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      BEAKER_HYPERVISOR: container_podman
+      BUNDLE_WITHOUT: development:test:release
+      BEAKER_PUPPET_COLLECTION: openvox8
+      BEAKER_SETFILE: 'centos10-64{hostname=centos10-64.example.com}'
+      BEAKER_FACTER_pulpcore_version: nightly
+      BEAKER_FACTER_pulpcore_baseurl: https://download.copr.fedorainfracloud.org/results/@theforeman/pulpcore-nightly-staging/rhel-10-x86_64/
+      BEAKER_FACTER_pulpcore_gpgkey: https://download.copr.fedorainfracloud.org/results/@theforeman/pulpcore-nightly-staging/pubkey.gpg
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: disable apparmor
+        run: |
+          # https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2093797
+          sudo aa-teardown || true
+          sudo systemctl disable --now apparmor.service
+      - name: Setup podman
+        run: |
+          systemctl start --user podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+      - name: Setup ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake beaker

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -33,7 +33,12 @@ describe 'with content cache enabled' do
     it { is_expected.to be_listening }
   end
 
-  describe service('redis') do
+  # RHEL/CentOS Stream 10 dropped Redis in favor of Valkey (a
+  # Redis-protocol-compatible fork); puppet-redis installs Package[valkey]/
+  # Service[valkey] there instead of Package[redis]/Service[redis].
+  redis_service_name = (fact('os.family') == 'RedHat' && fact('os.release.major').to_i >= 10) ? 'valkey' : 'redis'
+
+  describe service(redis_service_name) do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
   end


### PR DESCRIPTION
## Summary
- Adds a standalone `acceptance-el10` job to `.github/workflows/ci.yml` that runs Beaker directly against CentOS Stream 10 with Pulpcore `nightly`, sourced from the [Copr staging repo](https://copr.fedorainfracloud.org/coprs/g/theforeman/pulpcore-nightly-staging/) since nightly isn't published on `yum.theforeman.org` for EL10 yet.
- This intentionally does **not** touch `metadata.json`/`operatingsystem_support`: `metadata2gha` crosses every declared OS with every `beaker_facter` value, so adding EL10 there today would also try (and fail) unsupported combinations like `EL10 + 3.63`.
- This is a temporary, standalone job to validate the module installs on EL10 with nightly Pulpcore packages. Real integration into the supported-OS matrix is tracked in theforeman/el10_rebuild#25.

## Test plan
- [ ] CI: `acceptance-el10` job passes, confirming `pulpcore::repo` + `pulpcore-selinux` install cleanly on CentOS Stream 10 against the nightly Copr staging repo
- [ ] Existing `puppet` job (EL9 matrix) remains unaffected