### PR TITLE
Assert valkey service on EL10 in redis acceptance test

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -33,7 +33,12 @@ describe 'with content cache enabled' do
     it { is_expected.to be_listening }
   end
 
-  describe service('redis') do
+  # RHEL/CentOS Stream 10 dropped Redis in favor of Valkey (a
+  # Redis-protocol-compatible fork); puppet-redis installs Package[valkey]/
+  # Service[valkey] there instead of Package[redis]/Service[redis].
+  redis_service_name = (fact('os.family') == 'RedHat' && fact('os.release.major').to_i >= 10) ? 'valkey' : 'redis'
+
+  describe service(redis_service_name) do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
   end


### PR DESCRIPTION
## Summary
- RHEL/CentOS Stream 10 dropped Redis in favor of Valkey (a Redis-protocol-compatible fork). `puppet-redis` already handles this correctly on EL10 by installing `Package[valkey]`/`Service[valkey]` instead of `Package[redis]`/`Service[redis]`.
- `spec/acceptance/basic_spec.rb` hardcoded the service name `redis`, which fails on EL10 even though the underlying install works correctly.
- This makes the assertion OS-conditional: `valkey` on RedHat-family OSes release >= 10, `redis` otherwise.

Split out from #411 so this fix can land independently of the temporary EL10 CI job in that PR.

## Test plan
- [ ] Existing EL9 acceptance runs continue to assert `service('redis')` unchanged
- [ ] EL10 acceptance runs (see #411) assert `service('valkey')` and pass